### PR TITLE
Fix test execution time display in test adapter

### DIFF
--- a/BoostTestAdapter/Boost/Results/BoostXmlLog.cs
+++ b/BoostTestAdapter/Boost/Results/BoostXmlLog.cs
@@ -138,8 +138,8 @@ namespace BoostTestAdapter.Boost.Results
 
             if (testingTime != null)
             {
-                // Duration is in seconds i.e. remember to * 10 for milliseconds.
-                result.Duration = uint.Parse(testingTime.InnerText, CultureInfo.InvariantCulture);
+                // Boost test testing time is listed in microseconds
+                result.Duration = ulong.Parse(testingTime.InnerText, CultureInfo.InvariantCulture);
             }
 
             ParseTestCaseLogEntries(node.ChildNodes, result);

--- a/BoostTestAdapter/Boost/Results/TestResult.cs
+++ b/BoostTestAdapter/Boost/Results/TestResult.cs
@@ -116,7 +116,7 @@ namespace BoostTestAdapter.Boost.Results
         /// <summary>
         /// Duration of test in microseconds
         /// </summary>
-        public uint Duration { get; set; }
+        public ulong Duration { get; set; }
 
         /// <summary>
         /// Collection of related log entries.

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -48,7 +48,14 @@ namespace BoostTestAdapter.Utility.VisualStudio
             vsResult.Outcome = GetTestOutcome(result.Result);
 
             // Boost.Test.Result.TestResult.Duration is in microseconds
-            vsResult.Duration = TimeSpan.FromMilliseconds(result.Duration / 1000);
+            
+            // 1 millisecond = 10,000 ticks
+            // => 1 microsecond = 10 ticks
+            // Reference: https://msdn.microsoft.com/en-us/library/zz841zbz(v=vs.110).aspx
+            long ticks = (long) Math.Min((result.Duration * 10), long.MaxValue);
+            
+            // Clamp tick count to 1 in case Boost duration is listed as 0
+            vsResult.Duration = new TimeSpan(Math.Max(ticks, 1));
 
             if (result.LogEntries.Count > 0)
             {

--- a/BoostTestAdapterNunit/VSTestModelTest.cs
+++ b/BoostTestAdapterNunit/VSTestModelTest.cs
@@ -222,7 +222,7 @@ namespace BoostTestAdapterNunit
         /// <returns>A TimeSpan describing the microsecond duration</returns>
         private TimeSpan Microseconds(int value)
         {
-            return TimeSpan.FromMilliseconds(Math.Truncate(value / 1000F));
+            return TimeSpan.FromTicks(value * 10);
         }
         
         /// <summary>
@@ -328,7 +328,7 @@ namespace BoostTestAdapterNunit
             AssertVSTestModelProperties(result);
 
             Assert.That(result.Outcome, Is.EqualTo(TestOutcome.Skipped));
-            Assert.That(result.Duration, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(result.Duration, Is.EqualTo(TimeSpan.FromTicks(1)));
 
             Assert.That(result.Messages.Count, Is.EqualTo(0));
         }
@@ -358,7 +358,9 @@ namespace BoostTestAdapterNunit
             AssertVSTestModelProperties(result);
 
             Assert.That(result.Outcome, Is.EqualTo(TestOutcome.Failed));
-            Assert.That(result.Duration, Is.EqualTo(TimeSpan.FromTicks(0)));
+
+            // A 0 duration should list as 1 tick to avoid UI issues in the test adapter
+            Assert.That(result.Duration, Is.EqualTo(TimeSpan.FromTicks(1)));
 
             AssertVsTestModelError(result, exception);
 


### PR DESCRIPTION
In certain cases, very fast tests to not have their execution listed correctly and using the 'Duration' view in the test adapter makes it more difficult to identify a passing/failing test.

This occurs since Boost Test Framework identifies the test execution time as being a total of 0 microseconds. In such cases, clamping the test execution time to 1 tick solves this issue and test execution time is correctly identified as '< 1' in the test adapter.