### PR TITLE
Fix command prompt windows popping up in Visual Studio 2015

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -138,7 +138,7 @@ namespace BoostTestAdapter.Boost.Runner
 
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
-                CreateNoWindow = false,
+                CreateNoWindow = true,
                 UseShellExecute = false,
                 WindowStyle = ProcessWindowStyle.Hidden,
                 WorkingDirectory = args.WorkingDirectory,


### PR DESCRIPTION
When using Visual Studio 2015, running (not debugging) tests generated a command-prompt window per test.

Setting the 'CreateNoWindow' attribute properly to true fixes this.