### PR TITLE
Allow 'catch_system_errors' to be Configured via .runsettings File

### DIFF
--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -499,7 +499,7 @@ namespace BoostTestAdapter
         /// <returns>A BoostTestRunnerCommandLineArgs structure for the provided source</returns>
         private BoostTestRunnerCommandLineArgs GetDefaultArguments(string source, BoostTestAdapterSettings settings)
         {
-            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
+            BoostTestRunnerCommandLineArgs args = settings.CommandLineArgs.Clone();
 
             args.WorkingDirectory = Path.GetDirectoryName(source);
 

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -24,6 +24,8 @@ namespace BoostTestAdapter.Settings
         {
             this.TestRunnerSettings = new BoostTestRunnerSettings();
 
+            this.CommandLineArgs = new BoostTestRunnerCommandLineArgs();
+
             // Set default configuration values
 
             this.FailTestOnMemoryLeak = false;
@@ -33,6 +35,10 @@ namespace BoostTestAdapter.Settings
             this.LogLevel = LogLevel.TestSuite;
 
             this.ExternalTestRunner = null;
+
+            this.CatchSystemErrors = true;
+
+            this.DetectFloatingPointExceptions = false;
         }
 
         #region Properties
@@ -62,12 +68,43 @@ namespace BoostTestAdapter.Settings
         [DefaultValue(LogLevel.TestSuite)]
         public LogLevel LogLevel { get; set; }
 
+        [DefaultValue(true)]
+        public bool CatchSystemErrors
+        {
+            get
+            {
+                return this.CommandLineArgs.CatchSystemErrors;
+            }
+
+            set
+            {
+                this.CommandLineArgs.CatchSystemErrors = value;
+            }
+        }
+
+        [DefaultValue(false)]
+        public bool DetectFloatingPointExceptions
+        {
+            get
+            {
+                return this.CommandLineArgs.DetectFPExceptions;
+            }
+
+            set
+            {
+                this.CommandLineArgs.DetectFPExceptions = value;
+            }
+        }
+
         public ExternalBoostTestRunnerSettings ExternalTestRunner { get; set; }
 
         #endregion Serialisable Fields
 
         [XmlIgnore]
         public BoostTestRunnerSettings TestRunnerSettings { get; private set; }
+
+        [XmlIgnore]
+        public BoostTestRunnerCommandLineArgs CommandLineArgs { get; private set; }
 
         #endregion Properties
 

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -6,6 +6,40 @@ namespace BoostTestAdapterNunit
     [TestFixture]
     class BoostTestRunnerCommandLineArgsTest
     {
+        #region Utility Methods
+
+        /// <summary>
+        /// Generates a command line args instance with pre-determined values.
+        /// </summary>
+        /// <returns>A new BoostTestRunnerCommandLineArgs instance populated with pre-determined values.</returns>
+        private static BoostTestRunnerCommandLineArgs GenerateCommandLineArgs()
+        {
+            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
+
+            args.Tests.Add("test");
+            args.Tests.Add("suite/*");
+
+            args.LogFormat = OutputFormat.XML;
+            args.LogLevel = LogLevel.TestSuite;
+            args.LogFile = "log.xml";
+
+            args.ReportFormat = OutputFormat.XML;
+            args.ReportLevel = ReportLevel.Detailed;
+            args.ReportFile = "report.xml";
+
+            args.DetectMemoryLeaks = 0;
+
+            args.CatchSystemErrors = false;
+            args.DetectFPExceptions = true;
+
+            args.StandardOutFile = "stdout.log";
+            args.StandardErrorFile = "stderr.log";
+
+            return args;
+        }
+
+        #endregion Utility Methods
+
         #region Tests
 
         /// <summary>
@@ -30,25 +64,49 @@ namespace BoostTestAdapterNunit
         [Test]
         public void SampleCommandLineArgs()
         {
-            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
+            BoostTestRunnerCommandLineArgs args = GenerateCommandLineArgs();
 
-            args.Tests.Add("test");
-            args.Tests.Add("suite/*");
+            Assert.That(args.ToString(), Is.EqualTo("\"--run_test=test,suite/*\" \"--catch_system_errors=no\" \"--log_format=xml\" \"--log_level=test_suite\" \"--log_sink=log.xml\" \"--report_format=xml\" \"--report_level=detailed\" \"--report_sink=report.xml\" \"--detect_memory_leak=0\" \"--detect_fp_exceptions=yes\" > \"stdout.log\" 2> \"stderr.log\""));
+        }
 
-            args.LogFormat = OutputFormat.XML;
-            args.LogLevel = LogLevel.TestSuite;
-            args.LogFile = "log.xml";
+        /// <summary>
+        /// Verifies that cloning a command-line args structure is possible and correct.
+        /// 
+        /// Test aims:
+        ///     - Ensure that the command-line args structure is cloneable.
+        /// </summary>
+        [Test]
+        public void CloneCommandLineArgs()
+        {
+            BoostTestRunnerCommandLineArgs args = GenerateCommandLineArgs();
+            BoostTestRunnerCommandLineArgs clone = args.Clone();
+            
+            Assert.That(args.Tests, Is.EqualTo(clone.Tests));
+            Assert.That(args.WorkingDirectory, Is.EqualTo(clone.WorkingDirectory));
+            Assert.That(args.LogFile, Is.EqualTo(clone.LogFile));
+            Assert.That(args.LogFormat, Is.EqualTo(clone.LogFormat));
+            Assert.That(args.LogLevel, Is.EqualTo(clone.LogLevel));
+            Assert.That(args.ReportFile, Is.EqualTo(clone.ReportFile));
+            Assert.That(args.ReportFormat, Is.EqualTo(clone.ReportFormat));
+            Assert.That(args.ReportLevel, Is.EqualTo(clone.ReportLevel));
+            Assert.That(args.DetectMemoryLeaks, Is.EqualTo(clone.DetectMemoryLeaks));
+            Assert.That(args.StandardErrorFile, Is.EqualTo(clone.StandardErrorFile));
+            Assert.That(args.StandardOutFile, Is.EqualTo(clone.StandardOutFile));
+            
+            Assert.That(args.ShowProgress, Is.EqualTo(clone.ShowProgress));
+            Assert.That(args.BuildInfo, Is.EqualTo(clone.BuildInfo));
+            Assert.That(args.AutoStartDebug, Is.EqualTo(clone.AutoStartDebug));
+            Assert.That(args.CatchSystemErrors, Is.EqualTo(clone.CatchSystemErrors));
+            Assert.That(args.BreakExecPath, Is.EqualTo(clone.BreakExecPath));
+            Assert.That(args.ColorOutput, Is.EqualTo(clone.ColorOutput));
+            Assert.That(args.ResultCode, Is.EqualTo(clone.ResultCode));
+            Assert.That(args.Random, Is.EqualTo(clone.Random));
+            Assert.That(args.UseAltStack, Is.EqualTo(clone.UseAltStack));
+            Assert.That(args.DetectFPExceptions, Is.EqualTo(clone.DetectFPExceptions));
+            Assert.That(args.SavePattern, Is.EqualTo(clone.SavePattern));
+            Assert.That(args.ListContent, Is.EqualTo(clone.ListContent));
 
-            args.ReportFormat = OutputFormat.XML;
-            args.ReportLevel = ReportLevel.Detailed;
-            args.ReportFile = "report.xml";
-
-            args.DetectMemoryLeaks = 0;
-
-            args.StandardOutFile = "stdout.log";
-            args.StandardErrorFile = "stderr.log";
-
-            Assert.That(args.ToString(), Is.EqualTo("\"--run_test=test,suite/*\" \"--log_format=xml\" \"--log_level=test_suite\" \"--log_sink=log.xml\" \"--report_format=xml\" \"--report_level=detailed\" \"--report_sink=report.xml\" \"--detect_memory_leak=0\" > \"stdout.log\" 2> \"stderr.log\""));
+            Assert.That(args.ToString(), Is.EqualTo(clone.ToString()));
         }
 
         #endregion Tests

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -43,6 +43,8 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.ConditionalInclusionsFilteringEnabled, Is.True);
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.TestSuite));
             Assert.That(settings.ExternalTestRunner, Is.Null);
+            Assert.That(settings.DetectFloatingPointExceptions, Is.False);
+            Assert.That(settings.CatchSystemErrors, Is.True);
         }
 
         /// <summary>
@@ -141,6 +143,9 @@ namespace BoostTestAdapterNunit
         {
             BoostTestAdapterSettings settings = Parse("BoostTestAdapterNunit.Resources.Settings.sample.2.runsettings");
             Assert.That(settings.TimeoutMilliseconds, Is.EqualTo(100));
+
+            Assert.That(settings.CatchSystemErrors, Is.False);
+            Assert.That(settings.DetectFloatingPointExceptions, Is.True);
         }
 
         /// <summary>

--- a/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
@@ -37,6 +37,11 @@
 
 	<!-- BoostTest adapter -->
 	<BoostTest>
-		<TimeoutMilliseconds>100</TimeoutMilliseconds>
+        <TimeoutMilliseconds>100</TimeoutMilliseconds>
+        
+        <CatchSystemErrors>false</CatchSystemErrors>
+        
+        <!-- Test case-sensitivity -->
+        <DetectFloatingPointExceptions>1</DetectFloatingPointExceptions>
 	</BoostTest>
 </RunSettings>

--- a/README.md
+++ b/README.md
@@ -332,6 +332,19 @@ To modify the amount of log information displayed in the test adapter, the ```<L
 
 By default, this option is set to ```TestSuite```. Please refer to the _log_level_ [Boost Runtime Configuration](http://www.boost.org/doc/libs/1_55_0/libs/test/doc/html/utf/user-guide/runtime-config/reference.html) for further information about log verbosity.
 
+#### Disable Catching of System Errors
+
+By default, the Boost UTF and the Boost unit test adapter catches system errors. To disable this behaviour, set the  ```<CatchSystemErrors>``` configuration option to ```false``` (or ```0```).
+
+Please refer to the _catch_system_errors_ [Boost Runtime Configuration](http://www.boost.org/doc/libs/1_55_0/libs/test/doc/html/utf/user-guide/runtime-config/reference.html) for further information.
+
+
+#### Enable Floating Point Exceptions
+
+The Boost UTF framework allows for trapping floating point exceptions. In order to enable this functionality through the Boost unit test adapter, set the  ```<DetectFloatingPointExceptions>``` configuration option to ```true``` (or ```1```).
+
+Please refer to the _detect_fp_exceptions_ [Boost Runtime Configuration](http://www.boost.org/doc/libs/1_55_0/libs/test/doc/html/utf/user-guide/runtime-config/reference.html) for further information.
+
 #### Utilization of an External Test Runner
 
 The Boost Unit Test Adapter supports the utilization of an External Test Runner for test discovery and test execution. This is useful in case a user, for example, wants to compile the Boost unit tests project as a dll rather than as an executable.


### PR DESCRIPTION
As requested by issue #13, the command-line parameters 'catch_system_errors' and 'detect_fp_exceptions' are now configurable via the .runsettings file via the boolean configuration options 'CatchSystemError' and 'DetectFloatingPointExceptions' respectively.