### PR TITLE
Limit .gitattributes to unit test 'resources' folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* -crlf
+BoostTestAdapterNunit/Resources/ -crlf


### PR DESCRIPTION
Limit .gitattributes to 'resources' folder to avoid having massive changes being recorded for source files.