### PR TITLE
Improve the Performance of Test Discovery

### DIFF
--- a/BoostTestAdapter/BoostTestDiscovererInternal.cs
+++ b/BoostTestAdapter/BoostTestDiscovererInternal.cs
@@ -102,14 +102,20 @@ namespace BoostTestAdapter
                                         SourceCode = sr.ReadToEnd()
                                     };
 
-                                    /*
-                                     * it is important that the pre-processor defines at project level are not modified
-                                     * because every source file in the project has to have the same starting point.
-                                     */
+                                    // Filter out any false positives and quickly reject files which do not contain any Boost Unit Test eye-catchers
+                                    if ( ShouldConsiderSourceFile(cppSourceFile.SourceCode) )
+                                    {
+                                        /*
+                                         * it is important that the pre-processor defines at project level are not modified
+                                         * because every source file in the project has to have the same starting point.
+                                         */
 
-                                    ApplySourceFilter(cppSourceFile, new Defines(projectInfo.DefinesHandler));
-                                    //call to cpy ctor
-                                    DiscoverBoostTests(cppSourceFile, source, discoverySink);
+                                        //call to cpy ctor
+                                        Defines definitions = new Defines(projectInfo.DefinesHandler);
+
+                                        ApplySourceFilter(cppSourceFile, definitions);
+                                        DiscoverBoostTests(cppSourceFile, source, discoverySink);
+                                    }
                                 }
                                 catch (Exception ex)
                                 {
@@ -131,6 +137,13 @@ namespace BoostTestAdapter
             {
                 Logger.Error("the solutionInfo object was found to be null whilst");
             }
+        }
+
+        private static bool ShouldConsiderSourceFile(string source)
+        {
+            // NOTE Using .Contains can be slightly faster then performing a Regex.IsMatch for a set of strings
+            // Reference: http://cc.davelozinski.com/c-sharp/fastest-way-to-check-if-a-string-occurs-within-a-string
+            return source.Contains("BOOST_");
         }
 
         /// <summary>

--- a/BoostTestAdapterNunit/Resources/SourceFiltering/QuotedStringsFilterTest_FilteredSourceCode.cpp
+++ b/BoostTestAdapterNunit/Resources/SourceFiltering/QuotedStringsFilterTest_FilteredSourceCode.cpp
@@ -1,4 +1,4 @@
-﻿#include "header"
+﻿#include 
 
 cout <<  << newline <<  << endl; 
 cout <<  << tab <<  << endl;

--- a/BoostTestAdapterNunit/SourceFiltersTest.cs
+++ b/BoostTestAdapterNunit/SourceFiltersTest.cs
@@ -23,7 +23,7 @@ namespace BoostTestAdapterNunit
         [TestCase("BOOST_MESSAGE(\"This is a \\\"test\",\"This is a test\");", Result = "BOOST_MESSAGE(,);")]
         [TestCase("BOOST_MESSAGE(\"This is a test\\\"\");", Result = "BOOST_MESSAGE();")]
         [TestCase("BOOST_MESSAGE(\"This is a just a\\\" test\");", Result = "BOOST_MESSAGE();")]
-        [TestCase("#include \"stdafx.h\"", Result = "#include \"stdafx.h\"")]
+        [TestCase("#include \"stdafx.h\"", Result = "#include ")]
         public string FilterQuotedString(string input)
         {
             ISourceFilter filter = new QuotedStringsFilter();


### PR DESCRIPTION
According to #8, test discovery can be slow especially on large code bases.

This fix attempts to improve the performance (slightly) by discarding any files which do not contain the 'BOOST_' macro prefix. By limiting the search space, discovery can be faster.

Additionally, the 'QuotedStringFilter' filter has been slightly improved by coalescing the regular expressions into one, implying that the string is only scanned once.