### PR TITLE
Supported VS versions correctly enumerated in VS gallery

### DIFF
--- a/BoostTestPlugin/source.extension.vsixmanifest
+++ b/BoostTestPlugin/source.extension.vsixmanifest
@@ -15,9 +15,11 @@ In case of any issues please file an issue at https://github.com/etas/vs-boost-u
     <Tags>C++, Unit Testing, Testing, test explorer, TDD, Boost, Boost Test Library, Visual Studio, Test Adapter</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[11.0,14.0]" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[11.0,14.0]" Id="Microsoft.VisualStudio.Premium" />
-    <InstallationTarget Version="[11.0,14.0]" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[11.0,15.0)" Id="Microsoft.VisualStudio.Pro" />
+    <InstallationTarget Version="[11.0,14.0)" Id="Microsoft.VisualStudio.Premium" />
+    <InstallationTarget Version="[11.0,14.0)" Id="Microsoft.VisualStudio.Ultimate" />
+    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Community" />
+    <InstallationTarget Version="[14.0,15.0)" Id="Microsoft.VisualStudio.Enterprise" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />


### PR DESCRIPTION
Amended the manifest file so that the supported versions in the Visual Studio Gallery are properly listed.  This is a fix for issue #15. 

Tested correct build generation in VS2012, correct installation on a VS2015 Community edition only machine and on a machine having VS2012 Premium, VS2013 Professional and VS2015 Enterprise.

![image](https://cloud.githubusercontent.com/assets/13785378/10424289/59981230-70ce-11e5-9331-bf32aa384f13.png)

