### PR TITLE
Launch settings of the plugin project

### DIFF
--- a/BoostTestPlugin/BoostTestPlugin.csproj
+++ b/BoostTestPlugin/BoostTestPlugin.csproj
@@ -36,6 +36,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>BasicCorrectnessRules.ruleset</CodeAnalysisRuleSet>
+	<StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartArguments>/rootSuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -44,6 +47,9 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+	<StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartArguments>/rootSuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup>
     <!--MSBuild 4.0 property-->


### PR DESCRIPTION
Added elements StartAction StartProgam and StartArgument (which are generally found in csproj.user in the csproj file) so that the user can initiate a debug session using an experimental instance of Visual Studio [as mentioned in the wiki](https://github.com/etas/vs-boost-unit-test-adapter/wiki/Building#debugging-and-stepping-through-the-boost-unit-test-adapter-code) without having to configure these settings himself (or minimal configuration in case the default installation paths are not used or the respective visual studio version is not available).

The expected behaviour is that in case the user decides to override the settings via the properties window, the csproj.user is automatically created. If Visual Studio finds a csproj.user the settings in the csproj are overrided.