### PR TITLE
Add AppVeyor CI

### DIFF
--- a/BoostTestPlugin/BoostTestPlugin.csproj
+++ b/BoostTestPlugin/BoostTestPlugin.csproj
@@ -36,6 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>BasicCorrectnessRules.ruleset</CodeAnalysisRuleSet>
+    <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Boost Unit Test Adapter for Microsoft Visual Studio
+
+Build Status: [![Build status](https://ci.appveyor.com/api/projects/status/7awkwecxxtl36kje?svg=true)](https://ci.appveyor.com/project/netspiri/vs-boost-unit-test-adapter-du7c4)
+
 ### User Manual
 
 ## Contents

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,41 @@
+version: '1.0.5.{build}'
+os: Windows Server 2012
+install:
+# Download and install Visual Studio 2012 KB2707250 patch if Test Platform is older than the one we expect
+# Leave an update token on the build machine to identify that Visual Studio 2012 has been updated
+# NOTE Patch installation is a relatively lengthy process
+  - ps: |
+      if (!(Test-Path -Path "C:\kb2707250.msp.applied")) {
+        Write-Host -ForegroundColor Yellow "Downloading Visual Studio 2012 KB2707250 patch..."
+        (New-Object System.Net.WebClient).DownloadFile('http://go.microsoft.com/fwlink/?LinkId=621427&clcid=0x409', 'C:\kb2707250.msp')
+        Write-Host -ForegroundColor Yellow "Installing Visual Studio 2012 KB2707250 patch..."
+        Start-Process -FilePath "msiexec" -ArgumentList "/p C:\kb2707250.msp /quiet /norestart /log C:\kb2707250.msp.log REINSTALL=ALL REINSTALLMODE=omus" -Wait
+        Write-Output $null >> "C:\kb2707250.msp.applied"
+        Write-Host -ForegroundColor Green "Visual Studio 2012 KB2707250 installation completed successfully."
+      } else {
+        Write-Host -ForegroundColor Green "Found Visual Studio 2012 KB2707250 update token. Update skipped."
+      }
+# Download and execute madskristensen AppVeyor VSIX ExtensionScripts in order to update revision number before project build
+  - ps: (New-Object System.Net.WebClient).DownloadString("https://raw.githubusercontent.com/netspiri/ExtensionScripts/master/AppVeyor/vsix.ps1") | iex
+cache:
+# Retain NuGet packages unless packages.config is not updated to possibly minimize subsequent build times
+  - packages -> **\packages.config
+# Retain Visual Studio 2012 update token to identify whether this build machine has already update been updated
+  - C:\kb2707250.msp.applied
+# Retain the necessary Visual Studio 2012 update content to avoid re-updating on each build
+  - C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll
+configuration:
+  - Debug
+  - Release
+before_build:
+# Restore NuGet package dependencies for proper compilation
+  - cmd: nuget restore
+# Updates the version number in the .vsixmanifest and updates the AppVeyor build number to match
+  - ps: Vsix-IncrementVsixVersion .\BoostTestPlugin\source.extension.vsixmanifest $env:APPVEYOR_BUILD_NUMBER revision | Vsix-UpdateBuildVersion
+build:
+  verbosity: minimal
+test:
+  assemblies:
+    - BoostTestAdapterNunit\bin\$(configuration)\BoostTestAdapterNunit.dll
+artifacts:
+  - path: BoostTestPlugin\bin\$(configuration)\BoostUnitTestAdapter.vsix


### PR DESCRIPTION
Added AppVeyor configuration to repository along with build status badge as requested.

In brief, the build procedure attempts to:
- Update Visual Studio 2012 in case Update 3 is not installed
- Update VSIX version number to reflect AppVeyor's build number
- Build all projects (both Debug and Release configurations) along with static analysis
- Execute tests
- Expose VSIX installer as an artifact

Please note that the version number increments now need to be specified in ``appveyor.yml`` and ``source.extension.vsixmanifest``.