### PR TITLE
Fix Release Configuration for BoostTestPlugin

### DIFF
--- a/BoostTestPlugin/BoostTestPlugin.csproj
+++ b/BoostTestPlugin/BoostTestPlugin.csproj
@@ -45,6 +45,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <PropertyGroup>
     <!--MSBuild 4.0 property-->


### PR DESCRIPTION
Avoid automatic deployment of VSIX. This should reduce the warning messages listed in AppVeyor for a Release build job from 117 to 2.