### PR TITLE
Launch settings of the plugin project

### DIFF
--- a/BoostTestPlugin/BoostTestPlugin.csproj
+++ b/BoostTestPlugin/BoostTestPlugin.csproj
@@ -37,6 +37,9 @@
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>BasicCorrectnessRules.ruleset</CodeAnalysisRuleSet>
     <DeployExtension>False</DeployExtension>
+	<StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartArguments>/rootSuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -46,6 +49,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DeployExtension>False</DeployExtension>
+	<StartAction>Program</StartAction>
+    <StartProgram>C:\Program Files %28x86%29\Microsoft Visual Studio 14.0\Common7\IDE\devenv.exe</StartProgram>
+    <StartArguments>/rootSuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup>
     <!--MSBuild 4.0 property-->


### PR DESCRIPTION
Added elements StartAction StartProgam and StartArgument (which are generally found in csproj.user in the csproj file) so that the user can initiate a debug session using an experimental instance of Visual Studio as mentioned in the wiki without having to configure these settings himself (or minimal configuration in case the default installation paths are not used or the respective visual studio version is not available).

The expected behaviour is that in case the user decides to override the settings via the properties window, the csproj.user is automatically created. If Visual Studio finds a csproj.user the settings in the csproj are overriden.