### PR TITLE
Configurable Test Batching

### DIFF
--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -145,6 +145,11 @@
     <Compile Include="SourceFilter\SingleLineCommentFilter.cs" />
     <Compile Include="SourceFilter\SourceDiscoveryException.cs" />
     <Compile Include="SourceFilter\SourceFilterFactory.cs" />
+    <Compile Include="TestBatch\IndividualTestBatchStrategy.cs" />
+    <Compile Include="TestBatch\ITestBatchingStrategy.cs" />
+    <Compile Include="TestBatch\SourceTestBatchStrategy.cs" />
+    <Compile Include="TestBatch\TestBatchStrategy.cs" />
+    <Compile Include="TestBatch\TestSuiteTestBatchStrategy.cs" />
     <Compile Include="Utility\Code.cs" />
     <Compile Include="Utility\CommandEvaluator.cs" />
     <Compile Include="Utility\CommandLine.cs" />

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -44,6 +44,8 @@ namespace BoostTestAdapter.Settings
             this.CatchSystemErrors = true;
 
             this.DetectFloatingPointExceptions = false;
+
+            this.TestBatchStrategy = TestBatch.Strategy.TestCase;
         }
 
         #region Properties
@@ -116,6 +118,9 @@ namespace BoostTestAdapter.Settings
         }
 
         public ExternalBoostTestRunnerSettings ExternalTestRunner { get; set; }
+
+        [DefaultValue(TestBatch.Strategy.TestSuite)]
+        public TestBatch.Strategy TestBatchStrategy { get; set; }
 
         #endregion Serialisable Fields
 

--- a/BoostTestAdapter/TestBatch/ITestBatchingStrategy.cs
+++ b/BoostTestAdapter/TestBatch/ITestBatchingStrategy.cs
@@ -1,0 +1,26 @@
+﻿// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.Collections.Generic;
+using BoostTestAdapter.Utility;
+
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+
+namespace BoostTestAdapter.TestBatch
+{
+    /// <summary>
+    /// Defines a test batching strategy. Groups a collection of tests into a 
+    /// series of test runs for eventual execution.
+    /// </summary>
+    public interface ITestBatchingStrategy
+    {
+        /// <summary>
+        /// Groups the provided test cases into a series of test run executions.
+        /// </summary>
+        /// <param name="tests">The tests which are to be executed</param>
+        /// <returns>An enumeration of test runs, possibly aggregating multiple test cases into a single test run</returns>
+        IEnumerable<TestRun> BatchTests(IEnumerable<VSTestCase> tests);
+    }
+}

--- a/BoostTestAdapter/TestBatch/IndividualTestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/IndividualTestBatchStrategy.cs
@@ -1,0 +1,53 @@
+﻿// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.Collections.Generic;
+using System.Linq;
+using BoostTestAdapter.Boost.Runner;
+using BoostTestAdapter.Settings;
+using BoostTestAdapter.Utility;
+
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+
+namespace BoostTestAdapter.TestBatch
+{
+    /// <summary>
+    /// An ITestBatchingStrategy which allocates a test run per test case.
+    /// </summary>
+    public class IndividualTestBatchStrategy : TestBatchStrategy
+    {
+        public IndividualTestBatchStrategy(IBoostTestRunnerFactory testRunnerFactory, BoostTestAdapterSettings settings, CommandLineArgsBuilder argsBuilder) :
+            base(testRunnerFactory, settings, argsBuilder)
+        {
+        }
+
+        #region TestBatchStrategy
+
+        public override IEnumerable<TestRun> BatchTests(IEnumerable<VSTestCase> tests)
+        {
+            // Group by source
+            var sources = tests.GroupBy(test => test.Source);
+            foreach (var source in sources)
+            {
+                IBoostTestRunner runner = GetTestRunner(source.Key);
+                if (runner == null)
+                {
+                    continue;
+                }
+
+                // Group by tests individually
+                foreach (VSTestCase test in source)
+                {
+                    BoostTestRunnerCommandLineArgs args = BuildCommandLineArgs(runner.Source);
+                    args.Tests.Add(test.FullyQualifiedName);
+
+                    yield return new TestRun(runner, new VSTestCase[] { test }, args, this.Settings.TestRunnerSettings);
+                }
+            }
+        }
+
+        #endregion TestBatchStrategy
+    }
+}

--- a/BoostTestAdapter/TestBatch/SourceTestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/SourceTestBatchStrategy.cs
@@ -1,0 +1,55 @@
+// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.Collections.Generic;
+using System.Linq;
+using BoostTestAdapter.Boost.Runner;
+using BoostTestAdapter.Settings;
+using BoostTestAdapter.Utility;
+
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+
+namespace BoostTestAdapter.TestBatch
+{
+    /// <summary>
+    /// An ITestBatchingStrategy implementation which provides a test run per provided source.
+    /// Regardless whether or not all tests in a source are requested to executed, all tests
+    /// contained within a source will be executed.
+    /// </summary>
+    public class SourceTestBatchStrategy : TestBatchStrategy
+    {
+        public SourceTestBatchStrategy(IBoostTestRunnerFactory testRunnerFactory, BoostTestAdapterSettings settings, CommandLineArgsBuilder argsBuilder) :
+            base(testRunnerFactory, settings, argsBuilder)
+        {
+        }
+
+        #region TestBatchStrategy
+
+        public override IEnumerable<TestRun> BatchTests(IEnumerable<VSTestCase> tests)
+        {
+            BoostTestRunnerSettings adaptedSettings = this.Settings.TestRunnerSettings.Clone();
+            adaptedSettings.RunnerTimeout = -1;
+
+            // Group by source
+            var sources = tests.GroupBy(test => test.Source);
+            foreach (var source in sources)
+            {
+                IBoostTestRunner runner = GetTestRunner(source.Key);
+                if (runner == null)
+                {
+                    continue;
+                }
+    
+                BoostTestRunnerCommandLineArgs args = BuildCommandLineArgs(source.Key);
+
+                // NOTE the --run_test command-line arg is left empty so that all tests are executed
+
+                yield return new TestRun(runner, source, args, adaptedSettings);
+            }
+        }
+
+        #endregion TestBatchStrategy
+    }
+}

--- a/BoostTestAdapter/TestBatch/TestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/TestBatchStrategy.cs
@@ -1,0 +1,86 @@
+﻿// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.Collections.Generic;
+using BoostTestAdapter.Boost.Runner;
+using BoostTestAdapter.Settings;
+using BoostTestAdapter.Utility;
+
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+
+namespace BoostTestAdapter.TestBatch
+{
+    /// <summary>
+    /// Identifies a test batching strategy
+    /// </summary>
+    public enum Strategy
+    {
+        Source,
+        TestSuite,
+        TestCase
+    }
+
+    /// <summary>
+    /// Factory function which populates a BoostTestRunnerCommandLineArgs based on the provided source and settings
+    /// </summary>
+    /// <param name="source">The test module source path</param>
+    /// <param name="settings">Adapter settings which are currently in use</param>
+    /// <returns>A BoostTestRunnerCommandLineArgs populated based on the provided information</returns>
+    public delegate BoostTestRunnerCommandLineArgs CommandLineArgsBuilder(string source, BoostTestAdapterSettings settings);
+
+    /// <summary>
+    /// Base utility class for ITestBatchingStrategy implementations.
+    /// </summary>
+    public abstract class TestBatchStrategy : ITestBatchingStrategy
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="testRunnerFactory">Factory which provides a test runner for a specific test source</param>
+        /// <param name="settings">Adapter settings which are currently in use</param>
+        /// <param name="argsBuilder">Factory function which populates a BoostTestRunnerCommandLineArgs based on the provided source and settings</param>
+        protected TestBatchStrategy(IBoostTestRunnerFactory testRunnerFactory, BoostTestAdapterSettings settings, CommandLineArgsBuilder argsBuilder)
+        {
+            this.TestRunnerFactory = testRunnerFactory;
+            this.Settings = settings;
+            this.ArgsBuilder = argsBuilder;
+        }
+
+        protected BoostTestAdapterSettings Settings { get; private set; }
+
+        private IBoostTestRunnerFactory TestRunnerFactory { get; set; }
+        private CommandLineArgsBuilder ArgsBuilder { get; set; }
+
+        #region TestBatchStrategy
+
+        public abstract IEnumerable<TestRun> BatchTests(IEnumerable<VSTestCase> tests);
+
+        #endregion TestBatchStrategy
+
+        /// <summary>
+        /// Factory function which returns an appropriate IBoostTestRunner
+        /// for the provided source or null if not applicable.
+        /// </summary>
+        /// <param name="source">The test source for which to retrieve the IBoostTestRunner</param>
+        /// <returns>An IBoostTestRunner valid for the provided source or null if none are available</returns>
+        protected IBoostTestRunner GetTestRunner(string source)
+        {
+            BoostTestRunnerFactoryOptions options = new BoostTestRunnerFactoryOptions();
+            options.ExternalTestRunnerSettings = (this.Settings == null) ? null : this.Settings.ExternalTestRunner;
+
+            return this.TestRunnerFactory.GetRunner(source, options);
+        }
+
+        /// <summary>
+        /// Generates a BoostTestRunnerCommandLineArgs for the specified source
+        /// </summary>
+        /// <param name="source">The test module source path</param>
+        /// <returns>A BoostTestRunnerCommandLineArgs populated based on the provided information</returns>
+        protected BoostTestRunnerCommandLineArgs BuildCommandLineArgs(string source)
+        {
+            return this.ArgsBuilder(source, this.Settings);
+        }
+    }
+}

--- a/BoostTestAdapter/TestBatch/TestSuiteTestBatchStrategy.cs
+++ b/BoostTestAdapter/TestBatch/TestSuiteTestBatchStrategy.cs
@@ -1,0 +1,64 @@
+﻿// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.Collections.Generic;
+using System.Linq;
+using BoostTestAdapter.Boost.Runner;
+using BoostTestAdapter.Settings;
+using BoostTestAdapter.Utility;
+using BoostTestAdapter.Utility.VisualStudio;
+
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+
+namespace BoostTestAdapter.TestBatch
+{
+    /// <summary>
+    /// An ITestBatchingStrategy which allocates a test run for test suites. All tests
+    /// contained within the same test suite are executed in one test run.
+    /// </summary>
+    public class TestSuiteTestBatchStrategy : TestBatchStrategy
+    {
+        public TestSuiteTestBatchStrategy(IBoostTestRunnerFactory testRunnerFactory, BoostTestAdapterSettings settings, CommandLineArgsBuilder argsBuilder) :
+            base(testRunnerFactory, settings, argsBuilder)
+        {
+        }
+
+        #region TestBatchStrategy
+
+        public override IEnumerable<TestRun> BatchTests(IEnumerable<VSTestCase> tests)
+        {
+            BoostTestRunnerSettings adaptedSettings = this.Settings.TestRunnerSettings.Clone();
+            adaptedSettings.RunnerTimeout = -1;
+
+            // Group by source
+            IEnumerable<IGrouping<string, VSTestCase>> sources = tests.GroupBy(test => test.Source);
+            foreach (IGrouping<string, VSTestCase> source in sources)
+            {
+                IBoostTestRunner runner = GetTestRunner(source.Key);
+                if (runner == null)
+                {
+                    continue;
+                }
+
+                // Group by test suite
+                var suiteGroups = source.GroupBy(test => test.Traits.First(trait => (trait.Name == VSTestModel.TestSuiteTrait)).Value);
+                foreach (var suiteGroup in suiteGroups)
+                {
+                    BoostTestRunnerCommandLineArgs args = BuildCommandLineArgs(source.Key);
+                    foreach (VSTestCase test in suiteGroup)
+                    {
+                        // List all tests by display name
+                        // but ensure that the first test is fully qualified so that remaining tests are taken relative to this test suite
+                        args.Tests.Add((args.Tests.Count == 0) ? test.FullyQualifiedName : test.DisplayName);
+                    }
+
+                    yield return new TestRun(runner, suiteGroup, args, adaptedSettings);
+                }
+            }
+        }
+
+        #endregion TestBatchStrategy
+    }
+}

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -9,6 +9,7 @@ using System.Xml;
 using BoostTestAdapter.Boost.Runner;
 using BoostTestAdapter.Settings;
 using BoostTestAdapter.Utility;
+using BoostTestAdapter.TestBatch;
 using BoostTestAdapterNunit.Fakes;
 using BoostTestAdapterNunit.Utility;
 using BoostTestAdapterNunit.Utility.Xml;
@@ -51,6 +52,7 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.ExternalTestRunner, Is.Null);
             Assert.That(settings.DetectFloatingPointExceptions, Is.False);
             Assert.That(settings.CatchSystemErrors, Is.True);
+            Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestCase));
         }
 
         /// <summary>
@@ -154,6 +156,7 @@ namespace BoostTestAdapterNunit
 
             Assert.That(settings.CatchSystemErrors, Is.False);
             Assert.That(settings.DetectFloatingPointExceptions, Is.True);
+            Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestSuite));
         }
 
         /// <summary>

--- a/BoostTestAdapterNunit/CorrectReferencedAssembliesTest.cs
+++ b/BoostTestAdapterNunit/CorrectReferencedAssembliesTest.cs
@@ -6,6 +6,7 @@
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using System.IO;
 
 namespace BoostTestAdapterNunit
 {
@@ -26,11 +27,11 @@ namespace BoostTestAdapterNunit
         [TestCase("VisualStudio2015Adapter.dll", "Microsoft.VisualStudio.VCProjectEngine", 14, TestName = "CorrectlyReferencedVisualStudio2015Adapter", Description = "Microsoft.VisualStudio.VCProjectEngine in VisualStudio2015Adapter must point to the VS2015 version")]
         public void CorrectReferences(string dll, string assemblyReferenceName, int versionMajor)
         {
-            var assembly = Assembly.LoadFrom(TestContext.CurrentContext.TestDirectory + "/" + dll);
-            var referencedAssemblies = assembly.GetReferencedAssemblies().Where(ass => ass.Name == assemblyReferenceName).ToList();
-            Assert.IsTrue(referencedAssemblies != null && referencedAssemblies.Count() == 1, "No reference to " + assemblyReferenceName + " found");
-            Assert.IsTrue(referencedAssemblies[0].Version.Major == versionMajor,
-                assemblyReferenceName + " in " + dll + " is referenced to an incorrect version");
+            var assembly = Assembly.LoadFrom(Path.Combine(TestContext.CurrentContext.TestDirectory, dll));
+            var referencedAssembly = assembly.GetReferencedAssemblies().FirstOrDefault(reference => (reference.Name == assemblyReferenceName));
+
+            Assert.That(referencedAssembly, Is.Not.Null, ("No reference to " + assemblyReferenceName + " found"));
+            Assert.That(referencedAssembly.Version.Major, Is.EqualTo(versionMajor), (assemblyReferenceName + " in " + dll + " is referenced to an incorrect version"));
         }
     }
 }

--- a/BoostTestAdapterNunit/Fakes/DefaultTestContext.cs
+++ b/BoostTestAdapterNunit/Fakes/DefaultTestContext.cs
@@ -123,7 +123,16 @@ namespace BoostTestAdapterNunit.Fakes
         /// <param name="path">The path to the embedded resource</param>
         public void LoadEmbeddedSettings(string path)
         {
-            this.SettingsXml = TestHelper.ReadEmbeddedResource(path);
+            LoadSettings(TestHelper.ReadEmbeddedResource(path));
+        }
+
+        /// <summary>
+        /// Loads the xml string and populates the registered providers accordingly.
+        /// </summary>
+        /// <param name="settingsXml">The xml string describing the settings configuration</param>
+        public void LoadSettings(string settingsXml)
+        {
+            this.SettingsXml = settingsXml;
 
             // Populate SettingProviders
             using (StringReader reader = new StringReader(this.SettingsXml))

--- a/BoostTestAdapterNunit/Resources/Settings/externalTestRunner.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/externalTestRunner.runsettings
@@ -11,5 +11,6 @@
 			</DiscoveryFileMap>
 			<ExecutionCommandLine>C:\ExternalTestRunner.exe --test "{source}"</ExecutionCommandLine>
 		</ExternalTestRunner>
-	</BoostTest>		
+        <TestBatchStrategy>TestCase</TestBatchStrategy>
+    </BoostTest>		
 </RunSettings>

--- a/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
@@ -37,11 +37,15 @@
 
 	<!-- BoostTest adapter -->
 	<BoostTest>
-    <ExecutionTimeoutMilliseconds>100</ExecutionTimeoutMilliseconds>
-    <DiscoveryTimeoutMilliseconds>100</DiscoveryTimeoutMilliseconds>
+        <ExecutionTimeoutMilliseconds>100</ExecutionTimeoutMilliseconds>
+        <DiscoveryTimeoutMilliseconds>100</DiscoveryTimeoutMilliseconds>
 
         <CatchSystemErrors>false</CatchSystemErrors>
 
+        
+        <!-- Test independent order from source code specification -->
+        <TestBatchStrategy>TestSuite</TestBatchStrategy>
+        
         <!-- Test case-sensitivity -->
         <DetectFloatingPointExceptions>1</DetectFloatingPointExceptions>
 	</BoostTest>

--- a/BoostTestAdapterNunit/Resources/Settings/sample.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/sample.runsettings
@@ -15,6 +15,7 @@
             <DiscoveryCommandLine>C:\ExternalTestRunner.exe --test "{source}" --list-debug "{out}"</DiscoveryCommandLine>
             <ExecutionCommandLine>C:\ExternalTestRunner.exe --test "{source}"</ExecutionCommandLine>
         </ExternalTestRunner>
+        <TestBatchStrategy>TestCase</TestBatchStrategy>
 	</BoostTest>
 
 </RunSettings>


### PR DESCRIPTION
Tests can now be grouped into lesser executions via the `TestBatchStrategy` configuration option. Available options:
- `Source` - Execute all tests within a source, regardless of selected tests from adapter. One test process spawned per test module (i.e. .`exe`).
- `TestSuite` - Execute selected tests grouped by test suite. One test process spawned per test suite.
- `TestCase` - Execute selected tests individually. One test process spawned per test case.

Attempts to resolve issue #37.