### PR TITLE
Fix 'list content' discovery

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -66,7 +66,7 @@ namespace BoostTestAdapter.Boost.Runner
 
         public virtual string Source
         {
-            get { return this.TestRunnerExecutable;  }
+            get { return this.TestRunnerExecutable; }
         }
 
         #endregion IBoostTestRunner

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -82,31 +82,31 @@ namespace BoostTestAdapter.Boost.Runner
     {
         #region Constants
 
-        private const string RunTestArg = "--run_test";
+        internal const string RunTestArg = "--run_test";
 
-        private const string LogFormatArg = "--log_format";
-        private const string LogLevelArg = "--log_level";
-        private const string LogSinkArg = "--log_sink";
+        internal const string LogFormatArg = "--log_format";
+        internal const string LogLevelArg = "--log_level";
+        internal const string LogSinkArg = "--log_sink";
 
-        private const string ReportFormatArg = "--report_format";
-        private const string ReportLevelArg = "--report_level";
-        private const string ReportSinkArg = "--report_sink";
+        internal const string ReportFormatArg = "--report_format";
+        internal const string ReportLevelArg = "--report_level";
+        internal const string ReportSinkArg = "--report_sink";
 
-        private const string DetectMemoryLeakArg = "--detect_memory_leak";
+        internal const string DetectMemoryLeakArg = "--detect_memory_leak";
 
-        private const string ShowProgressArg = "--show_progress";
-        private const string BuildInfoArg = "--build_info";
-        private const string AutoStartDebugArg = "--auto_start_dbg";
-        private const string CatchSystemErrorsArg = "--catch_system_errors";
-        private const string BreakExecPathArg = "--break_exec_path";
-        private const string ColorOutputArg = "--color_output";
-        private const string ResultCodeArg = "--result_code";
-        private const string RandomArg = "--random";
-        private const string UseAltStackArg = "--use_alt_stack";
-        private const string DetectFPExceptionsArg = "--detect_fp_exceptions";
-        private const string SavePatternArg = "--save_pattern";
-        private const string ListContentArg = "--list_content";
-        private const string HelpArg = "--help";
+        internal const string ShowProgressArg = "--show_progress";
+        internal const string BuildInfoArg = "--build_info";
+        internal const string AutoStartDebugArg = "--auto_start_dbg";
+        internal const string CatchSystemErrorsArg = "--catch_system_errors";
+        internal const string BreakExecPathArg = "--break_exec_path";
+        internal const string ColorOutputArg = "--color_output";
+        internal const string ResultCodeArg = "--result_code";
+        internal const string RandomArg = "--random";
+        internal const string UseAltStackArg = "--use_alt_stack";
+        internal const string DetectFPExceptionsArg = "--detect_fp_exceptions";
+        internal const string SavePatternArg = "--save_pattern";
+        internal const string ListContentArg = "--list_content";
+        internal const string HelpArg = "--help";
 
         private const string TestSeparator = ",";
 

--- a/BoostTestAdapter/BoostTestDiscoverer.cs
+++ b/BoostTestAdapter/BoostTestDiscoverer.cs
@@ -110,7 +110,10 @@ namespace BoostTestAdapter
                 foreach (var discoverer in results)
                 {
                     if (discoverer.Sources.Count > 0)
+                    {
+                        Logger.Info("Discovering ({0}):   -> [{1}]", discoverer.Discoverer.GetType().Name, string.Join(", ", discoverer.Sources));
                         discoverer.Discoverer.DiscoverTests(discoverer.Sources, discoveryContext, Logger.Instance, discoverySink);
+                    }
                 }
             }
             catch (Exception ex)

--- a/BoostTestAdapter/ListContentHelper.cs
+++ b/BoostTestAdapter/ListContentHelper.cs
@@ -3,10 +3,10 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+using System;
+using System.Threading;
 using System.Diagnostics;
 using BoostTestAdapter.Utility;
-using System.IO;
-using System.Threading;
 using BoostTestAdapter.Boost.Runner;
 
 namespace BoostTestAdapter
@@ -16,6 +16,8 @@ namespace BoostTestAdapter
     /// </summary>
     class ListContentHelper : IListContentHelper
     {
+        private const string _masterTestSuiteDebugSymbolName = "boost::unit_test::framework::master_test_suite";
+
         private readonly ProcessStartInfo _processStartInfo;
 
         public ListContentHelper()
@@ -31,11 +33,12 @@ namespace BoostTestAdapter
 
             Timeout = 5000;
         }
-
-
+        
+        /// <summary>
+        /// Process timeout for reading --help and --list_content output
+        /// </summary>
         public int Timeout { get; set; }
-
-
+        
         private void TimeoutTimerCallback(object state)
         {
             var process = (Process)state;
@@ -43,16 +46,27 @@ namespace BoostTestAdapter
                 process.Kill();
         }
 
+        #region IListContentHelper
+
         public bool IsListContentSupported(string exeName)
         {
             Code.Require(exeName, "exeName");
 
+            // Try to locate the master test suite debug symbol. If this is not available, this implies that:
+            // - Debug symbols are not available for the requested source
+            // - Debug symbols are available but the source is not a Boost Unit Test module
+            if (!LocateMasterTestSuite(exeName))
+            {
+                return false;
+            }
+            
+            // Once the master test suite is confirmed to exist, identify if the Boost Unit Test module
+            // has support for '--list_content' (i.e. Boost Test version >= 3). Identify this via the '--help' output.
             var args = new BoostTestRunnerCommandLineArgs
             {
                 Help = true
             };
-
-
+            
             string output;
             using (var p = new Process())
             using (Timer timeoutTimer = new Timer(TimeoutTimerCallback, p, System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite))
@@ -65,24 +79,13 @@ namespace BoostTestAdapter
                 output = p.StandardOutput.ReadToEnd();
                 p.WaitForExit(Timeout);
             }
-
-            args.Help = false;
-            args.ListContent = true;
-            if (!output.Contains(args.ToString()))
+            
+            if (!output.Contains(BoostTestRunnerCommandLineArgs.ListContentArg))
             {
                 return false;
             }
-
-            // check for the presence of PDB file
-            var exeDir = Path.GetDirectoryName(exeName);
-            var exeNameNoExt = Path.GetFileNameWithoutExtension(exeName);
-            var pdbName = exeNameNoExt + ".PDB";
-            var pdbPath = Path.Combine(exeDir, pdbName);
-            if (!File.Exists(pdbPath))
-                return false;
-
+            
             return true;
-
         }
 
         public string GetListContentOutput(string exeName)
@@ -112,6 +115,32 @@ namespace BoostTestAdapter
         public IDebugHelper CreateDebugHelper(string exeName)
         {
             return new DebugHelper(exeName);
+        }
+
+        #endregion IListContentHelper
+
+        /// <summary>
+        /// Determines whether the executable located at the provided path contains a debug symbol
+        /// for boost::unit_test::framework::master_test_suite.
+        /// </summary>
+        /// <param name="exeName">The path to the executable.</param>
+        /// <returns>true if a symbol for the Boost Unit Test master test suite was located; false otherwise.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        private bool LocateMasterTestSuite(string exeName)
+        {
+            try
+            {
+                using (IDebugHelper dbgHelp = CreateDebugHelper(exeName))
+                {
+                    return dbgHelp.ContainsSymbol(_masterTestSuiteDebugSymbolName);
+                }
+            }
+            catch (Exception)
+            {
+                Logger.Warn("Could not create a DBGHELP instance for '{0}' to determine whether symbols are available.", exeName);
+            }
+
+            return false;
         }
 
     }

--- a/BoostTestAdapter/Utility/IDebugHelper.cs
+++ b/BoostTestAdapter/Utility/IDebugHelper.cs
@@ -9,12 +9,17 @@ namespace BoostTestAdapter.Utility
     public interface IDebugHelper : IDisposable
     {
         /// <summary>
-        /// Searches for a symbol with the name similar to the input.
+        /// Searches for a symbol with the name <b>similar</b> to the input.
         /// </summary>
         /// <param name="name">The name of the symbol to be searched.</param>
-        /// <param name="symbols">All the symbols that contain the <paramref name="name"/> parameter in their name.</param>
-        /// <returns>True if the search was performed without errors. False otherwise.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#")]
-        bool LookupSymbol(string name, out IEnumerable<SymbolInfo> symbols);
+        /// <returns>All the symbols that contain the <paramref name="name"/> parameter in their name.</returns>
+        IEnumerable<SymbolInfo> LookupSymbols(string name);
+
+        /// <summary>
+        /// Determines whether or not a symbol with the <b>exact</b> provided name is available.
+        /// </summary>
+        /// <param name="name">The name of the symbol to search for.</param>
+        /// <returns>true if the symbol is available; false otherwise.</returns>
+        bool ContainsSymbol(string name);
     }
 }

--- a/BoostTestAdapterNunit/Fakes/StubDbgHelp.cs
+++ b/BoostTestAdapterNunit/Fakes/StubDbgHelp.cs
@@ -35,20 +35,25 @@ namespace BoostTestAdapterNunit.Fakes
             _symbolCache.AddRange(CreateFakeSuiteSymbols("Foo", "Foo"));
             _symbolCache.AddRange(CreateFakeTestSymbols("Foo", "Foo"));
         }
-
+        
         public void Dispose()
         {
             _symbolCache.Clear();
         }
 
-        public bool LookupSymbol(string name, out IEnumerable<SymbolInfo> symbols)
-        {
-            symbols = _symbolCache.Where(s => s.Name.Contains(name));
-            if (symbols.Any())
-                return true;
+        #region IDebugHelper
 
-            return false;
+        public IEnumerable<SymbolInfo> LookupSymbols(string name)
+        {
+            return _symbolCache.Where(s => s.Name.Contains(name));
         }
+
+        public bool ContainsSymbol(string name)
+        {
+            return LookupSymbols(name).Any();
+        }
+
+        #endregion IDebugHelper
 
         /// <summary>
         /// Creates a list of fake typical (found in a regular PDB) symbols for a test Suite.


### PR DESCRIPTION
- Fixes the check for '--list_content' from '--help' output.
- Tests for false-positive executables. Only executables containing the 'boost::unit_test::framework::master_test_suite' debug symbol are taken into consideration.
- Add logs to better identify which discoverer is being utilised.
- Minor refactoring.