### PR TITLE
Replace the file extension filter with a regular expression for the e…

### DIFF
--- a/BoostTestAdapter/BoostTestDiscovererFactory.cs
+++ b/BoostTestAdapter/BoostTestDiscovererFactory.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using BoostTestAdapter.Discoverers;
+using System.Text.RegularExpressions;
 
 namespace BoostTestAdapter
 {
@@ -95,7 +96,8 @@ namespace BoostTestAdapter
 
                     if (settings.ExternalTestRunner != null)
                     {
-                        if (settings.ExternalTestRunner.ExtensionType == Path.GetExtension(source))
+                        Regex matcher = new Regex(settings.ExternalTestRunner.ExtensionType);
++                       if (matcher.IsMatch(source))
                         {
                             externalDiscovererSources.Add(source);
                             continue;

--- a/BoostTestAdapter/BoostTestDiscovererFactory.cs
+++ b/BoostTestAdapter/BoostTestDiscovererFactory.cs
@@ -97,7 +97,7 @@ namespace BoostTestAdapter
                     if (settings.ExternalTestRunner != null)
                     {
                         Regex matcher = new Regex(settings.ExternalTestRunner.ExtensionType);
-+                       if (matcher.IsMatch(source))
+                        if (matcher.IsMatch(source))
                         {
                             externalDiscovererSources.Add(source);
                             continue;


### PR DESCRIPTION
Replace the file extension filter with a regular expression filter. This modification is backward compatible as ".dll" will match just like the extension filter would have.

The intention here is to provide a means of filtering out dlls containing test not only on it's extension. For example I want the test discovery to scan only files matching the pattern:
test\\\w+\.dll -> all files in directory test
.test.dll -> all files ending with .test.dll

Maybe I missed something and there is a better way of telling the Test Explorer which dlls contain tests and which do not.