### PR TITLE
Better identification for tests which are not found

### DIFF
--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -462,7 +462,7 @@ namespace BoostTestAdapter
             {
                 string text = File.ReadAllText(testRun.Arguments.ReportFile);
 
-                if (text.Trim() == TestNotFound)
+                if (text.Trim().StartsWith(TestNotFound))
                 {
                     return testRun.Tests.Select(GenerateNotFoundResult);
                 }


### PR DESCRIPTION
Test not found error has been updated from "Test setup error: no test cases matching filter" to "Test setup error: no test cases matching filter or all test cases were disabled" in recent Boost Test versions. This fix simply checks for the common starting sub-string instead of using exact comparison.

Tests which are not found are labelled with a warning icon accordingly.