### PR TITLE
Fix the handling of project paths containing spaces

### DIFF
--- a/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
@@ -108,7 +108,7 @@ namespace BoostTestAdapter.Boost.Runner
         {
             CommandEvaluator evaluator = new CommandEvaluator();
 
-            evaluator.SetVariable(SourcePlaceholder, source);
+            evaluator.SetVariable(SourcePlaceholder, "\"" + source + "\"");
 
             return evaluator;
         }

--- a/BoostTestAdapter/Discoverers/ExternalDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/ExternalDiscoverer.cs
@@ -102,8 +102,8 @@ namespace BoostTestAdapter.Discoverers
 
             CommandEvaluator evaluator = new CommandEvaluator();
 
-            evaluator.SetVariable("source", source);
-            evaluator.SetVariable("out", path);
+            evaluator.SetVariable("source", "\"" + source + "\"");
+            evaluator.SetVariable("out", "\"" + path + "\"");
 
             // Evaluate the discovery command
             CommandLine commandLine = new CommandLine

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -111,8 +111,8 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.ExternalTestRunner, Is.Not.Null);
             Assert.That(settings.ExternalTestRunner.ExtensionType, Is.EqualTo(".dll"));
             Assert.That(settings.ExternalTestRunner.DiscoveryMethodType, Is.EqualTo(DiscoveryMethodType.DiscoveryCommandLine));
-            Assert.That(settings.ExternalTestRunner.DiscoveryCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test \"{source}\" --list-debug \"{out}\""));
-            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test \"{source}\""));
+            Assert.That(settings.ExternalTestRunner.DiscoveryCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test {source} --list-debug {out} "));
+            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test {source} "));
         }
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace BoostTestAdapterNunit
             };
 
             Assert.That(settings.ExternalTestRunner.DiscoveryFileMap, Is.EqualTo(fileMap));
-            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test \"{source}\""));
+            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test {source} "));
         }
 
         /// <summary>


### PR DESCRIPTION
As requested, this branch has been rebased and squashed.

This provides a fix for the external runner, allowing to have path with spaces in the external runner executable path.