### PR TITLE
Fix 'list content' discovery

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -66,7 +66,7 @@ namespace BoostTestAdapter.Boost.Runner
 
         public virtual string Source
         {
-            get { return this.TestRunnerExecutable;  }
+            get { return this.TestRunnerExecutable; }
         }
 
         #endregion IBoostTestRunner

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -82,31 +82,31 @@ namespace BoostTestAdapter.Boost.Runner
     {
         #region Constants
 
-        private const string RunTestArg = "--run_test";
+        internal const string RunTestArg = "--run_test";
 
-        private const string LogFormatArg = "--log_format";
-        private const string LogLevelArg = "--log_level";
-        private const string LogSinkArg = "--log_sink";
+        internal const string LogFormatArg = "--log_format";
+        internal const string LogLevelArg = "--log_level";
+        internal const string LogSinkArg = "--log_sink";
 
-        private const string ReportFormatArg = "--report_format";
-        private const string ReportLevelArg = "--report_level";
-        private const string ReportSinkArg = "--report_sink";
+        internal const string ReportFormatArg = "--report_format";
+        internal const string ReportLevelArg = "--report_level";
+        internal const string ReportSinkArg = "--report_sink";
 
-        private const string DetectMemoryLeakArg = "--detect_memory_leak";
+        internal const string DetectMemoryLeakArg = "--detect_memory_leak";
 
-        private const string ShowProgressArg = "--show_progress";
-        private const string BuildInfoArg = "--build_info";
-        private const string AutoStartDebugArg = "--auto_start_dbg";
-        private const string CatchSystemErrorsArg = "--catch_system_errors";
-        private const string BreakExecPathArg = "--break_exec_path";
-        private const string ColorOutputArg = "--color_output";
-        private const string ResultCodeArg = "--result_code";
-        private const string RandomArg = "--random";
-        private const string UseAltStackArg = "--use_alt_stack";
-        private const string DetectFPExceptionsArg = "--detect_fp_exceptions";
-        private const string SavePatternArg = "--save_pattern";
-        private const string ListContentArg = "--list_content";
-        private const string HelpArg = "--help";
+        internal const string ShowProgressArg = "--show_progress";
+        internal const string BuildInfoArg = "--build_info";
+        internal const string AutoStartDebugArg = "--auto_start_dbg";
+        internal const string CatchSystemErrorsArg = "--catch_system_errors";
+        internal const string BreakExecPathArg = "--break_exec_path";
+        internal const string ColorOutputArg = "--color_output";
+        internal const string ResultCodeArg = "--result_code";
+        internal const string RandomArg = "--random";
+        internal const string UseAltStackArg = "--use_alt_stack";
+        internal const string DetectFPExceptionsArg = "--detect_fp_exceptions";
+        internal const string SavePatternArg = "--save_pattern";
+        internal const string ListContentArg = "--list_content";
+        internal const string HelpArg = "--help";
 
         private const string TestSeparator = ",";
 

--- a/BoostTestAdapter/BoostTestDiscoverer.cs
+++ b/BoostTestAdapter/BoostTestDiscoverer.cs
@@ -110,7 +110,10 @@ namespace BoostTestAdapter
                 foreach (var discoverer in results)
                 {
                     if (discoverer.Sources.Count > 0)
+                    {
+                        Logger.Info("Discovering ({0}):   -> [{1}]", discoverer.Discoverer.GetType().Name, string.Join(", ", discoverer.Sources));
                         discoverer.Discoverer.DiscoverTests(discoverer.Sources, discoveryContext, Logger.Instance, discoverySink);
+                    }
                 }
             }
             catch (Exception ex)

--- a/BoostTestAdapter/BoostTestDiscovererFactory.cs
+++ b/BoostTestAdapter/BoostTestDiscovererFactory.cs
@@ -52,7 +52,7 @@ namespace BoostTestAdapter
         /// <returns>An IBoostTestDiscoverer instance or null if one cannot be provided.</returns>
         public IBoostTestDiscoverer GetDiscoverer(string source, Settings.BoostTestAdapterSettings settings)
         {
-            var list = new List<string> { source };
+            var list = new[] { source };
             var results = GetDiscoverers(list, settings);
             if (results != null)
             {

--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -462,7 +462,7 @@ namespace BoostTestAdapter
             {
                 string text = File.ReadAllText(testRun.Arguments.ReportFile);
 
-                if (text.Trim().StartsWith(TestNotFound))
+                if (text.Trim().StartsWith(TestNotFound, StringComparison.Ordinal))
                 {
                     return testRun.Tests.Select(GenerateNotFoundResult);
                 }

--- a/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
@@ -21,6 +21,8 @@ namespace BoostTestAdapter.Discoverers
     /// </summary>
     internal class ListContentDiscoverer : IBoostTestDiscoverer
     {
+        private const int _indentation = 4;
+
         #region Constructors
 
         /// <summary>
@@ -53,6 +55,7 @@ namespace BoostTestAdapter.Discoverers
 
         #region IBoostTestDiscoverer
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public void DiscoverTests(IEnumerable<string> sources, IDiscoveryContext discoveryContext, IMessageLogger logger, ITestCaseDiscoverySink discoverySink)
         {
             Code.Require(sources, "sources");
@@ -76,28 +79,32 @@ namespace BoostTestAdapter.Discoverers
                         var lines = output.Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
                         foreach (var l in lines)
                         {
+                            var isEnabled = false;
+
+                            // Sanitize test unit name
                             var unitName = l.Trim();
                             if (unitName.EndsWith("*", StringComparison.Ordinal))
-                                unitName = unitName.Substring(0, unitName.Length - 1);
+                            {
+                                unitName = unitName.Substring(0, unitName.Length - 1).TrimEnd();
+                                isEnabled = true;
+                            }
 
-                            var currentLineIndentation = l.TrimEnd().LastIndexOf(' ') + 1;
+                            // Identify indentation level
+                            var currentLineIndentation = 0;
+                            while (char.IsWhiteSpace(l[currentLineIndentation]))
+                            {
+                                ++currentLineIndentation;
+                            }
 
-                            // pop levels from the name builder to reach the current one
+                            // Pop levels from the name builder to reach the current one
                             while (currentLineIndentation <= previousLineIndentation)
                             {
                                 suiteNameBuilder.Pop();
-                                previousLineIndentation -= 4;
+                                previousLineIndentation -= _indentation;
                             }
-
-                            // Retrieve all the symbols that contains <unitname> in their name.
-                            // If no symbols can be retrieved, we skip the current unitName because 
-                            // we cannot assume what kind of unit (test or suit) it is.
-                            IEnumerable<SymbolInfo> syms;
-                            if (!dbgHelp.LookupSymbol(unitName, out syms))
-                                continue;
-
-                            // Check if the unit is a Test or a Suite.
-                            var testSymbol = GetTestSymbol(suiteNameBuilder, unitName, syms);
+                            
+                            // Try to locate a test case symbol for the test unit. If one is not found, assume it is a test suite.
+                            var testSymbol = dbgHelp.LookupSymbol(BuildTestCaseSymbolName(suiteNameBuilder, unitName));
                             if (testSymbol == null)
                             {
                                 // Suite
@@ -108,7 +115,6 @@ namespace BoostTestAdapter.Discoverers
                             else
                             {
                                 // Test
-                                var isEnabled = l.Contains("*");
                                 var testCase = TestCaseUtils.CreateTestCase(
                                     source,
                                     new SourceFileInfo(testSymbol.FileName, testSymbol.LineNumber),
@@ -127,40 +133,37 @@ namespace BoostTestAdapter.Discoverers
                 }
             }
         }
-
+        
         /// <summary>
-        /// Searches in a list of SymbolInfo the one that identifies a Test.
+        /// Based on the parent test unit hierarchy and the provided test unit, generates a fully-qualified test case symbol name for the provided test unit.
         /// </summary>
-        /// <param name="suiteNameBuilder">Qualified name builder.</param>
-        /// <param name="unitName">The name of the unit to be searched.</param>
-        /// <param name="syms">The list of the symbols.</param>
-        /// <returns>A SymbolInfo if <paramref name="unitName"/> is a test method.</returns>
-        private static SymbolInfo GetTestSymbol(QualifiedNameBuilder suiteNameBuilder, string unitName, IEnumerable<SymbolInfo> syms)
+        /// <param name="suiteNameBuilder">The parent test unit hierarchy.</param>
+        /// <param name="unitName">The test unit.</param>
+        /// <returns>The fully-qualified <b>test case</b> symbol name for the provided test unit.</returns>
+        private static string BuildTestCaseSymbolName(QualifiedNameBuilder suiteNameBuilder, string unitName)
         {
-            try
-            {
-                var fullyQualifiedName = unitName;
-                
-                if (!string.IsNullOrEmpty(suiteNameBuilder.ToString()))
-                    fullyQualifiedName = string.Format(
-                        CultureInfo.InvariantCulture,
-                        "{0}::{1}",
-                        suiteNameBuilder.ToString().Replace("/", "::"),
-                        unitName
-                    );
+            var fullyQualifiedName = unitName;
 
-                var symbolName = string.Format(
+            string testUnitLocator = suiteNameBuilder.ToString();
+
+            // If the test is located within a test suite, qualify accordingly
+            if (!string.IsNullOrEmpty(testUnitLocator))
+            { 
+                fullyQualifiedName = string.Format(
                     CultureInfo.InvariantCulture,
-                    "{0}::test_method",
-                    fullyQualifiedName
+                    "{0}::{1}",
+                    testUnitLocator.Replace("/", "::"),
+                    unitName
                 );
+            }
 
-                return syms.FirstOrDefault(s => s.Name == symbolName);
-            }
-            catch (Exception)
-            {
-                throw;
-            }
+            var symbolName = string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}::test_method",
+                fullyQualifiedName
+            );
+            
+            return symbolName;
         }
 
         #endregion

--- a/BoostTestAdapter/ListContentHelper.cs
+++ b/BoostTestAdapter/ListContentHelper.cs
@@ -3,10 +3,10 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+using System;
+using System.Threading;
 using System.Diagnostics;
 using BoostTestAdapter.Utility;
-using System.IO;
-using System.Threading;
 using BoostTestAdapter.Boost.Runner;
 
 namespace BoostTestAdapter
@@ -16,6 +16,9 @@ namespace BoostTestAdapter
     /// </summary>
     class ListContentHelper : IListContentHelper
     {
+        //private const string _masterTestSuiteDebugSymbolName = "boost::unit_test::framework::master_test_suite";
+        private const string _listContentDebugSymbolName = "boost::unit_test::runtime_config::list_content";
+
         private readonly ProcessStartInfo _processStartInfo;
 
         public ListContentHelper()
@@ -31,11 +34,12 @@ namespace BoostTestAdapter
 
             Timeout = 5000;
         }
-
-
+        
+        /// <summary>
+        /// Process timeout for reading --list_content output
+        /// </summary>
         public int Timeout { get; set; }
-
-
+        
         private void TimeoutTimerCallback(object state)
         {
             var process = (Process)state;
@@ -43,46 +47,29 @@ namespace BoostTestAdapter
                 process.Kill();
         }
 
+        #region IListContentHelper
+        
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         public bool IsListContentSupported(string exeName)
         {
             Code.Require(exeName, "exeName");
 
-            var args = new BoostTestRunnerCommandLineArgs
+            // Try to locate the list_content function debug symbol. If this is not available, this implies that:
+            // - Debug symbols are not available for the requested source
+            // - Debug symbols are available but the source is not a Boost Unit Test version >= 3 module
+            try
             {
-                Help = true
-            };
-
-
-            string output;
-            using (var p = new Process())
-            using (Timer timeoutTimer = new Timer(TimeoutTimerCallback, p, System.Threading.Timeout.Infinite, System.Threading.Timeout.Infinite))
+                using (IDebugHelper dbgHelp = CreateDebugHelper(exeName))
+                {
+                    return dbgHelp.ContainsSymbol(_listContentDebugSymbolName);
+                }
+            }
+            catch (Exception ex)
             {
-                _processStartInfo.FileName = exeName;
-                _processStartInfo.Arguments = args.ToString();
-                p.StartInfo = _processStartInfo;
-                p.Start();
-                timeoutTimer.Change(Timeout, Timeout);
-                output = p.StandardOutput.ReadToEnd();
-                p.WaitForExit(Timeout);
+                Logger.Warn("Could not create a DBGHELP instance for '{0}' to determine whether symbols are available.", exeName);
             }
 
-            args.Help = false;
-            args.ListContent = true;
-            if (!output.Contains(args.ToString()))
-            {
-                return false;
-            }
-
-            // check for the presence of PDB file
-            var exeDir = Path.GetDirectoryName(exeName);
-            var exeNameNoExt = Path.GetFileNameWithoutExtension(exeName);
-            var pdbName = exeNameNoExt + ".PDB";
-            var pdbPath = Path.Combine(exeDir, pdbName);
-            if (!File.Exists(pdbPath))
-                return false;
-
-            return true;
-
+            return false;
         }
 
         public string GetListContentOutput(string exeName)
@@ -105,6 +92,7 @@ namespace BoostTestAdapter
                 output = p.StandardError.ReadToEnd(); // for some reason the list content output is in the standard error
                 p.WaitForExit(Timeout);
             }
+
             return output;
         }
 
@@ -114,5 +102,6 @@ namespace BoostTestAdapter
             return new DebugHelper(exeName);
         }
 
+        #endregion IListContentHelper
     }
 }

--- a/BoostTestAdapter/Utility/IDebugHelper.cs
+++ b/BoostTestAdapter/Utility/IDebugHelper.cs
@@ -9,12 +9,17 @@ namespace BoostTestAdapter.Utility
     public interface IDebugHelper : IDisposable
     {
         /// <summary>
-        /// Searches for a symbol with the name similar to the input.
+        /// Searches for a symbol with the the <b>exact</b> provided name.
         /// </summary>
         /// <param name="name">The name of the symbol to be searched.</param>
-        /// <param name="symbols">All the symbols that contain the <paramref name="name"/> parameter in their name.</param>
-        /// <returns>True if the search was performed without errors. False otherwise.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "1#")]
-        bool LookupSymbol(string name, out IEnumerable<SymbolInfo> symbols);
+        /// <returns>The found symbol with the given name or null if one cannot be found.</returns>
+        SymbolInfo LookupSymbol(string name);
+
+        /// <summary>
+        /// Determines whether or not a symbol with the <b>exact</b> provided name is available.
+        /// </summary>
+        /// <param name="name">The name of the symbol to search for.</param>
+        /// <returns>true if the symbol is available; false otherwise.</returns>
+        bool ContainsSymbol(string name);
     }
 }

--- a/BoostTestAdapter/Utility/Logger.cs
+++ b/BoostTestAdapter/Utility/Logger.cs
@@ -122,6 +122,19 @@ namespace BoostTestAdapter.Utility
         }
 
         /// <summary>
+        /// Logs the provided message at the 'Trace' severity level. Uses a format, args pair to construct the log message.
+        /// </summary>
+        /// <param name="format">Format string</param>
+        /// <param name="args">Arguments for the format string</param>
+        public static void Trace(string format, params object[] args)
+        {
+#if TRACE
+            // Represent a trace log as a regular info log for proper output
+            Info(format, args);
+#endif
+        }
+
+        /// <summary>
         /// Disposes the underlying log module.
         /// </summary>
         public static void Shutdown()

--- a/BoostTestAdapterNunit/Fakes/StubDbgHelp.cs
+++ b/BoostTestAdapterNunit/Fakes/StubDbgHelp.cs
@@ -35,20 +35,25 @@ namespace BoostTestAdapterNunit.Fakes
             _symbolCache.AddRange(CreateFakeSuiteSymbols("Foo", "Foo"));
             _symbolCache.AddRange(CreateFakeTestSymbols("Foo", "Foo"));
         }
-
+        
         public void Dispose()
         {
             _symbolCache.Clear();
         }
 
-        public bool LookupSymbol(string name, out IEnumerable<SymbolInfo> symbols)
+        #region IDebugHelper
+        
+        public SymbolInfo LookupSymbol(string name)
         {
-            symbols = _symbolCache.Where(s => s.Name.Contains(name));
-            if (symbols.Any())
-                return true;
-
-            return false;
+            return _symbolCache.FirstOrDefault(sym => (sym.Name == name));
         }
+
+        public bool ContainsSymbol(string name)
+        {
+            return LookupSymbol(name) != null;
+        }
+
+        #endregion IDebugHelper
 
         /// <summary>
         /// Creates a list of fake typical (found in a regular PDB) symbols for a test Suite.


### PR DESCRIPTION
- Fixes the check for '--list_content'. Makes use of debug symbols to determine Boost Test executables with 'list_content' support.
- Optimized debug symbol lookup by minimizing managed-native switches.
- Add logs to better identify which discoverer is being utilised.
- Minor refactoring.

Improves over PR #57.

Relates to issue #53.