### PR TITLE
BOOST 1.59 Fix & Multiline Test Case / Test Suite Support

### DIFF
--- a/BoostTestAdapter/Boost/Results/BoostXmlLog.cs
+++ b/BoostTestAdapter/Boost/Results/BoostXmlLog.cs
@@ -67,12 +67,21 @@ namespace BoostTestAdapter.Boost.Results
 
         public override void Parse(TestResultCollection collection)
         {
-            XmlDocument doc = new XmlDocument();
-            doc.Load(this.InputStream);
-
-            if (doc.DocumentElement.Name == Xml.TestLog)
+            // serge: now log output for dependent test cases supported, the have additional XML
+            // element, that corrupts XML document structure
+            using (XmlTextReader xtr = new XmlTextReader(this.InputStream, XmlNodeType.Element, null))
             {
-                ParseTestUnitsLog(doc.DocumentElement.ChildNodes, new QualifiedNameBuilder(), collection);
+                while (xtr.Read())
+                {
+                    if (xtr.NodeType == XmlNodeType.Element && xtr.Name == Xml.TestLog)
+                    {
+                        XmlDocument doc = new XmlDocument();
+                        XmlElement elemTestLog = doc.CreateElement(Xml.TestLog);
+                        elemTestLog.InnerXml = xtr.ReadInnerXml();
+                        ParseTestUnitsLog(elemTestLog.ChildNodes, new QualifiedNameBuilder(), collection);
+                        break;
+                    }
+                }
             }
         }
 

--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/BoostTestAdapterNunit/BoostTestResultTest.cs
+++ b/BoostTestAdapterNunit/BoostTestResultTest.cs
@@ -141,8 +141,11 @@ namespace BoostTestAdapterNunit
                     testResult.LogEntries.FirstOrDefault(
                         e =>
                         {
-                            var entryDetail = Regex.Replace(entry.Detail, @"\r|\n", string.Empty);
-                            var eDetail = Regex.Replace(e.Detail, @"\r|\n", string.Empty);
+                            // serge: In BoostXmlLog.Parse(TestResultCollection collection) method
+                            // Xml document is recreated. There are insignificant whitespaces
+                            // are appearing during transformation. So let's truncate them.
+                            var entryDetail = Regex.Replace(entry.Detail, @"\r|\n\s+", string.Empty);
+                            var eDetail = Regex.Replace(e.Detail, @"\r|\n\s+", string.Empty);
                             return (e.ToString() == entry.ToString()) && (eDetail == entryDetail);
                         });
                 Assert.That(found, Is.Not.Null);

--- a/BoostTestPlugin/BoostTestPlugin.csproj
+++ b/BoostTestPlugin/BoostTestPlugin.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>


### PR DESCRIPTION
+ ability to parse multiline BOOST_TEST_ ...  definitions
supported multiline macros
BOOST_AUTO_TEST_SUITE()
BOOST_FIXTURE_TEST_SUITE(),
BOOST_AUTO_TEST_CASE(),
BOOST_FIXTURE_TEST_CASE()
BOOST_AUTO_TEST_CASE_TEMPLATE()
+ log output for dependent test cases supported
correctly process xml log report for test cases with boost::test_tools::depends_on() decorator
+ FIX: BoostTestResultTest.AssertLogDetails(BoostTestResult testResult, uint duration, IList<LogEntry> entries) remove whitespaces during xml log comparison

Unit test results: all tests are passed
https://ci.appveyor.com/project/sergegers/vs-boost-unit-test-adapter/build/1.0.6.10