### PR TITLE
Temporarily Revert --list_content Discovery

### DIFF
--- a/BoostTestAdapter/BoostTestDiscovererFactory.cs
+++ b/BoostTestAdapter/BoostTestDiscovererFactory.cs
@@ -79,6 +79,9 @@ namespace BoostTestAdapter
             if ((sources == null) || (!sources.Any()))
                 return discoverers;
 
+            // Use default settings in case they are not provided by client code
+            settings = settings ?? new Settings.BoostTestAdapterSettings();
+
             // sources that can be run on the external runner
             var externalDiscovererSources = new List<string>();
 
@@ -88,27 +91,25 @@ namespace BoostTestAdapter
             // sources that do NOT support the list-content parameter
             var sourceCodeDiscovererSources = new List<string>();
 
+            _listContentHelper.Timeout = settings.DiscoveryTimeoutMilliseconds;
+
             foreach (var source in sources)
             {
-                if (settings != null)
+                if (settings.ExternalTestRunner != null)
                 {
-                    _listContentHelper.Timeout = settings.DiscoveryTimeoutMilliseconds;
-
-                    if (settings.ExternalTestRunner != null)
+                    Regex matcher = new Regex(settings.ExternalTestRunner.ExtensionType);
+                    if (matcher.IsMatch(source))
                     {
-                        Regex matcher = new Regex(settings.ExternalTestRunner.ExtensionType);
-                        if (matcher.IsMatch(source))
-                        {
-                            externalDiscovererSources.Add(source);
-                            continue;
-                        }
+                        externalDiscovererSources.Add(source);
+                        continue;
                     }
                 }
 
+                // Skip modules which are not .exe
                 if (Path.GetExtension(source) != BoostTestDiscoverer.ExeExtension)
                     continue;
 
-                if (_listContentHelper.IsListContentSupported(source))
+                if (settings.UseListContent && _listContentHelper.IsListContentSupported(source))
                 {
                     listContentDiscovererSources.Add(source);
                 }

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -46,6 +46,8 @@ namespace BoostTestAdapter.Settings
             this.DetectFloatingPointExceptions = false;
 
             this.TestBatchStrategy = TestBatch.Strategy.TestCase;
+
+            this.UseListContent = false;
         }
 
         #region Properties
@@ -122,6 +124,9 @@ namespace BoostTestAdapter.Settings
         [DefaultValue(TestBatch.Strategy.TestSuite)]
         public TestBatch.Strategy TestBatchStrategy { get; set; }
 
+        [DefaultValue(false)]
+        public bool UseListContent { get; set; }
+
         #endregion Serialisable Fields
 
         [XmlIgnore]
@@ -129,7 +134,7 @@ namespace BoostTestAdapter.Settings
 
         [XmlIgnore]
         public BoostTestRunnerCommandLineArgs CommandLineArgs { get; private set; }
-
+        
         #endregion Properties
 
         #region TestRunSettings

--- a/BoostTestAdapterNunit/BoostTestDiscovererFactoryTest.cs
+++ b/BoostTestAdapterNunit/BoostTestDiscovererFactoryTest.cs
@@ -15,6 +15,15 @@ namespace BoostTestAdapterNunit
     [TestFixture]
     class BoostTestDiscovererFactoryTest
     {
+        /// <summary>
+        /// Default factory function for adapter settings
+        /// </summary>
+        /// <returns>The default settings for use within this test fixture</returns>
+        private static BoostTestAdapterSettings CreateAdapterSettings()
+        {
+            // Prefer the use of ListContent where possible
+            return new BoostTestAdapterSettings() { UseListContent = true };
+        }
 
         #region Tests
 
@@ -38,7 +47,7 @@ namespace BoostTestAdapterNunit
             var stubListContentHelper = new StubListContentHelper();
             var boostTestDiscovererFactory = new BoostTestDiscovererFactory(stubListContentHelper);
 
-            var results = boostTestDiscovererFactory.GetDiscoverers(sources, new BoostTestAdapterSettings());
+            var results = boostTestDiscovererFactory.GetDiscoverers(sources, CreateAdapterSettings());
 
             Assert.That(results.Count(), Is.EqualTo(2));
             Assert.That(results.FirstOrDefault(x => x.Discoverer is ListContentDiscoverer), Is.Not.Null);
@@ -74,7 +83,8 @@ namespace BoostTestAdapterNunit
 
             var stubListContentHelper = new StubListContentHelper();
             var boostTestDiscovererFactory = new BoostTestDiscovererFactory(stubListContentHelper);
-            BoostTestAdapterSettings settings = new BoostTestAdapterSettings();
+
+            BoostTestAdapterSettings settings = CreateAdapterSettings();
             settings.ExternalTestRunner = new ExternalBoostTestRunnerSettings
             {
                 ExtensionType = BoostTestDiscoverer.DllExtension
@@ -119,7 +129,8 @@ namespace BoostTestAdapterNunit
 
             var stubListContentHelper = new StubListContentHelper();
             var boostTestDiscovererFactory = new BoostTestDiscovererFactory(stubListContentHelper);
-            BoostTestAdapterSettings settings = new BoostTestAdapterSettings();
+
+            BoostTestAdapterSettings settings = CreateAdapterSettings();
             settings.ExternalTestRunner = new ExternalBoostTestRunnerSettings
             {
                 ExtensionType = BoostTestDiscoverer.ExeExtension
@@ -150,7 +161,7 @@ namespace BoostTestAdapterNunit
         {
             var stubListContentHelper = new StubListContentHelper();
             var boostTestDiscovererFactory = new BoostTestDiscovererFactory(stubListContentHelper);
-            BoostTestAdapterSettings settings = new BoostTestAdapterSettings();
+            BoostTestAdapterSettings settings = CreateAdapterSettings();
             settings.ExternalTestRunner = new ExternalBoostTestRunnerSettings
             {
                 ExtensionType = BoostTestDiscoverer.ExeExtension
@@ -190,7 +201,7 @@ namespace BoostTestAdapterNunit
         {
             var stubListContentHelper = new StubListContentHelper();
             var boostTestDiscovererFactory = new BoostTestDiscovererFactory(stubListContentHelper);
-            BoostTestAdapterSettings settings = new BoostTestAdapterSettings();
+            BoostTestAdapterSettings settings = CreateAdapterSettings();
             settings.ExternalTestRunner = new ExternalBoostTestRunnerSettings
             {
                 ExtensionType = BoostTestDiscoverer.DllExtension

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -53,6 +53,7 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.DetectFloatingPointExceptions, Is.False);
             Assert.That(settings.CatchSystemErrors, Is.True);
             Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestCase));
+            Assert.That(settings.UseListContent, Is.False);
         }
 
         /// <summary>
@@ -157,6 +158,8 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.CatchSystemErrors, Is.False);
             Assert.That(settings.DetectFloatingPointExceptions, Is.True);
             Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestSuite));
+
+            Assert.That(settings.UseListContent, Is.True);
         }
 
         /// <summary>

--- a/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
+++ b/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
@@ -40,22 +40,31 @@ namespace BoostTestAdapterNunit
         /// Test aims:
         ///     - Ensure that the proper ITestDiscoverer type is provided for the requested source.
         /// </summary>
-        // Exe types
-        [TestCase("test.exe", null, Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.exe", ".dll", Result = typeof(ListContentDiscoverer))]
-        [TestCase("test.exe", ".exe", Result = typeof(ExternalDiscoverer))]
+        // Exe types (SourceCodeDiscovery)
+        [TestCase("test.exe", false, null, Result = typeof(SourceCodeDiscoverer))]
+        [TestCase("test.exe", true, null, Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.exe", false, ".dll", Result = typeof(SourceCodeDiscoverer))]
+        [TestCase("test.exe", true, ".dll", Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.exe", false, ".exe", Result = typeof(ExternalDiscoverer))]
+        [TestCase("test.exe", true, ".exe", Result = typeof(ExternalDiscoverer))]
         // Dll types
-        [TestCase("test.dll", null, Result = null)]
-        [TestCase("test.dll", ".dll", Result = typeof(ExternalDiscoverer))]
-        [TestCase("test.dll", ".exe", Result = null)]
+        [TestCase("test.dll", false, null, Result = null)]
+        [TestCase("test.dll", true, null, Result = null)]
+        [TestCase("test.dll", false, ".dll", Result = typeof(ExternalDiscoverer))]
+        [TestCase("test.dll", true, ".dll", Result = typeof(ExternalDiscoverer))]
+        [TestCase("test.dll", false, ".exe", Result = null)]
+        [TestCase("test.dll", true, ".exe", Result = null)]
         // Invalid extension types
-        [TestCase("test.txt", null, Result = null)]
-        [TestCase("test.txt", ".dll", Result = null)]
-        [TestCase("test.txt", ".exe", Result = null)]
-        public Type TestDiscovererProvisioning(string source, string externalExtension)
+        [TestCase("test.txt", false, null, Result = null)]
+        [TestCase("test.txt", true, null, Result = null)]
+        [TestCase("test.txt", false, ".dll", Result = null)]
+        [TestCase("test.txt", true, ".dll", Result = null)]
+        [TestCase("test.txt", false, ".exe", Result = null)]
+        [TestCase("test.txt", true, ".exe", Result = null)]
+        public Type TestDiscovererProvisioning(string source, bool useListContent, string externalExtension)
         {
             ExternalBoostTestRunnerSettings externalSettings = null;
-
+            
             if (!string.IsNullOrEmpty(externalExtension))
             {
                 externalSettings = new ExternalBoostTestRunnerSettings { ExtensionType = externalExtension };
@@ -63,7 +72,8 @@ namespace BoostTestAdapterNunit
 
             BoostTestAdapterSettings settings = new BoostTestAdapterSettings()
             {
-                ExternalTestRunner = externalSettings
+                ExternalTestRunner = externalSettings,
+                UseListContent = useListContent
             };
 
             IBoostTestDiscoverer discoverer = this.Factory.GetDiscoverer(source, settings);

--- a/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
@@ -41,12 +41,13 @@
         <DiscoveryTimeoutMilliseconds>100</DiscoveryTimeoutMilliseconds>
 
         <CatchSystemErrors>false</CatchSystemErrors>
-
         
         <!-- Test independent order from source code specification -->
         <TestBatchStrategy>TestSuite</TestBatchStrategy>
         
         <!-- Test case-sensitivity -->
         <DetectFloatingPointExceptions>1</DetectFloatingPointExceptions>
+
+        <UseListContent>true</UseListContent>
 	</BoostTest>
 </RunSettings>


### PR DESCRIPTION
Given recent development regarding the `--list_content` feature, list content discovery is now only enabled if users explicitly define the `<UseListContent>` configuration element to `true` in the `.runsettings` configuration file.

By default, the `SourceCodeDiscoverer` is now in use.

`--list_content` discovery will be reworked to use `--list_content=DOT` for milestone 1.0.7.0.