### PR TITLE
FIX: supply log_format, report_format runtime parameters in uppercase

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -517,7 +517,8 @@ namespace BoostTestAdapter.Boost.Runner
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase")]
         private static string OutputFormatToString(OutputFormat value)
         {
-            return value.ToString().ToLowerInvariant();
+            // serge: boost 1.60 requires uppercase input
+            return value.ToString();    //.ToLowerInvariant();
         }
 
         /// <summary>

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -70,8 +70,8 @@ namespace BoostTestAdapterNunit
         public void SampleCommandLineArgs()
         {
             BoostTestRunnerCommandLineArgs args = GenerateCommandLineArgs();
-
-            Assert.That(args.ToString(), Is.EqualTo("\"--run_test=test,suite/*\" \"--catch_system_errors=no\" \"--log_format=xml\" \"--log_level=test_suite\" \"--log_sink=log.xml\" \"--report_format=xml\" \"--report_level=detailed\" \"--report_sink=report.xml\" \"--detect_memory_leak=0\" \"--detect_fp_exceptions=yes\" > \"stdout.log\" 2> \"stderr.log\""));
+            // serge: boost 1.60 requires uppercase input
+            Assert.That(args.ToString(), Is.EqualTo("\"--run_test=test,suite/*\" \"--catch_system_errors=no\" \"--log_format=XML\" \"--log_level=test_suite\" \"--log_sink=log.xml\" \"--report_format=XML\" \"--report_level=detailed\" \"--report_sink=report.xml\" \"--detect_memory_leak=0\" \"--detect_fp_exceptions=yes\" > \"stdout.log\" 2> \"stderr.log\""));
         }
 
         /// <summary>

--- a/BoostTestPlugin/BoostTestPlugin.csproj
+++ b/BoostTestPlugin/BoostTestPlugin.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>


### PR DESCRIPTION
(requred in BOOST 1.60)