### PR TITLE
Remove 'Reset Build Number to 0' Logic

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,6 @@ before_build:
   - ps: |
       $revision = $env:APPVEYOR_BUILD_NUMBER
 
-      if ($env:APPVEYOR_REPO_TAG -eq $true) {
-        $revision = 0
-      }
-
       Vsix-IncrementVsixVersion .\BoostTestPlugin\source.extension.vsixmanifest $revision revision | Vsix-UpdateBuildVersion -updateOnPullRequests
 build:
   verbosity: minimal


### PR DESCRIPTION
Currently, tagged commits have their build number reset to 0.

Given recent discussions mentioned in issue #52, this logic has been removed and the revision number now simply auto-increments.