### PR TITLE
Set 'Environment' from Visual Studio Configuration Properties

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -153,6 +153,14 @@ namespace BoostTestAdapter.Boost.Runner
                 RedirectStandardInput = false
             };
 
+            if ( !string.IsNullOrEmpty(args.Environment) )
+            {
+                // Sets Path variable accordingly to the environment
+                string currentEnvironment = startInfo.EnvironmentVariables["Path"];
+
+                startInfo.EnvironmentVariables["Path"] = string.IsNullOrEmpty(currentEnvironment) ? args.Environment : (currentEnvironment + ";" + args.Environment);
+            }
+
             return startInfo;
         }
 

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -171,6 +171,11 @@ namespace BoostTestAdapter.Boost.Runner
         public string WorkingDirectory { get; set; }
 
         /// <summary>
+        /// Specifies the process's environment
+        /// </summary>
+        public string Environment { get; set; }
+
+        /// <summary>
         /// List of fully qualified name tests which are to be executed.
         /// </summary>
         public IList<string> Tests { get; private set; }
@@ -632,6 +637,8 @@ namespace BoostTestAdapter.Boost.Runner
             BoostTestRunnerCommandLineArgs clone = new BoostTestRunnerCommandLineArgs();
 
             clone.WorkingDirectory = this.WorkingDirectory;
+
+            clone.Environment = this.Environment;
 
             // Deep copy
             clone.Tests = new List<string>(this.Tests);

--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -385,24 +385,25 @@ namespace BoostTestAdapter
         }
 
         /// <summary>
-        /// Returns default working directory by resolving configurations from different possible resources
+        /// Retrieves and assignes parameters by resolving configurations from different possible resources
         /// </summary>
         /// <param name="source">The TestCases source</param>
         /// <param name="settings">The Boost Test adapter settings currently in use</param>
         /// <returns>A string for the default working directory</returns>
-        private string GetDefaultWorkingDirectory(string source, BoostTestAdapterSettings settings)
+        private void GetDebugConfigurationProperties(string source, BoostTestAdapterSettings settings, BoostTestRunnerCommandLineArgs args)
         {
             string workingDirectory = null;
+            string environment = null;
 
             bool applyVSWorkingDirectory = false;
 
             // Get the currently loaded VisualStudio instance
             if ( null != _vsProvider )
-            {
-                var vs = _vsProvider.Instance;
-                                
+            {                                               
                 try
                 {
+                    var vs = _vsProvider.Instance;
+
                     foreach (var project in vs.Solution.Projects)
                     {
                         var configuration = project.ActiveConfiguration;
@@ -410,6 +411,7 @@ namespace BoostTestAdapter
                         if ( string.Equals(source, configuration.PrimaryOutput, StringComparison.Ordinal) )
                         {
                             workingDirectory = configuration.VSDebugConfiguration.WorkingDirectory;
+                            environment = configuration.VSDebugConfiguration.Environment;
                             applyVSWorkingDirectory = true;
                             break;
                         }
@@ -433,7 +435,8 @@ namespace BoostTestAdapter
                 }
             }
 
-            return workingDirectory;
+            args.WorkingDirectory = workingDirectory;
+            args.Environment = environment;
         }
 
         /// <summary>
@@ -446,7 +449,7 @@ namespace BoostTestAdapter
         {
             BoostTestRunnerCommandLineArgs args = settings.CommandLineArgs.Clone();
 
-            args.WorkingDirectory = GetDefaultWorkingDirectory(source, settings);
+            GetDebugConfigurationProperties(source, settings, args);
             
             string filename = Path.GetFileName(source);
 

--- a/BoostTestAdapter/Utility/ProcessStartInfoEx.cs
+++ b/BoostTestAdapter/Utility/ProcessStartInfoEx.cs
@@ -44,9 +44,13 @@ namespace BoostTestAdapter.Utility
             {
                 string variable = entry.Key.ToString();
 
-                if (!clone.EnvironmentVariables.ContainsKey(variable))
+                if ( clone.EnvironmentVariables.ContainsKey(variable) )
                 {
-                    clone.EnvironmentVariables.Add(variable, entry.Value.ToString());
+                    clone.EnvironmentVariables[variable] = info.EnvironmentVariables[variable];
+                }
+                else
+                {
+                    clone.EnvironmentVariables.Add(variable, entry.Value.ToString());                    
                 }
             }
 

--- a/BoostTestAdapterNunit/Utility/VisualStudioInstanceBuilders.cs
+++ b/BoostTestAdapterNunit/Utility/VisualStudioInstanceBuilders.cs
@@ -117,6 +117,7 @@ namespace BoostTestAdapterNunit.Utility
         private IList<string> _sourcesFullFilePath = new List<string>(); 
         private Defines _definitions = new Defines();
         private string _workingDirectory = string.Empty;
+        private string _environment = string.Empty;
 
         /// <summary>
         /// Identifies the name of the project
@@ -148,6 +149,17 @@ namespace BoostTestAdapterNunit.Utility
         public FakeProjectBuilder WorkingDirectory(string output)
         {
             this._workingDirectory = output;
+            return this;
+        }
+
+        /// <summary>
+        /// Identifies the project's environment
+        /// </summary>
+        /// <param name="output"></param>
+        /// <returns></returns>
+        public FakeProjectBuilder Environment(string output)
+        {
+            this._environment = output;
             return this;
         }
 
@@ -196,6 +208,7 @@ namespace BoostTestAdapterNunit.Utility
 
             IVSDebugConfiguration fakeVSConfiguration = A.Fake<IVSDebugConfiguration>();
             A.CallTo(() => fakeVSConfiguration.WorkingDirectory).Returns(this._workingDirectory);
+            A.CallTo(() => fakeVSConfiguration.Environment).Returns(this._environment);
 
             A.CallTo(() => fakeConfiguration.VSDebugConfiguration).Returns(fakeVSConfiguration);
 

--- a/BoostTestAdapterNunit/VisualStudio2012AdapterTest.cs
+++ b/BoostTestAdapterNunit/VisualStudio2012AdapterTest.cs
@@ -34,6 +34,8 @@ namespace BoostTestAdapterNunit
         private const string DefaultOutput = "test.boostd.exe";
         private const string DefaultWorkingDirectory = "$(ProjectDir)";
         private readonly static string DefaultEvaluatedWorkingDirectory = Path.GetTempPath();
+        private const string DefaultEnvironment = "$(EnvDir)";
+        private readonly static string DefaultEvaluatedEnvironment = Path.GetTempPath();
 
         #endregion Test Data
 
@@ -73,13 +75,22 @@ namespace BoostTestAdapterNunit
 
                 A.CallTo(() => this.VCDebugSettings.WorkingDirectory).Returns(DefaultWorkingDirectory);
 
+                A.CallTo(() => this.VCDebugSettings.Environment).Returns(DefaultEnvironment);
+
                 A.CallTo(() => this.VCConfiguration.Evaluate(A<string>._)).ReturnsLazily((string input) =>
                 {
+                    // fake the evaluation process by converting the MACRO to something else
                     if (input.Equals(DefaultWorkingDirectory))
                     {
                         return DefaultEvaluatedWorkingDirectory;
                     }
-                    return DefaultWorkingDirectory;
+                    else if (input.Equals(DefaultEnvironment))
+                    {
+                        return DefaultEvaluatedEnvironment;
+                    }
+                    else {}
+
+                    return input;
                 });
             }
 
@@ -108,6 +119,7 @@ namespace BoostTestAdapterNunit
             Assert.That(this.Project.Name, Is.EqualTo(DefaultProjectName));
             Assert.That(this.Project.ActiveConfiguration.PrimaryOutput, Is.EqualTo(DefaultOutput));
             Assert.That(this.Project.ActiveConfiguration.VSDebugConfiguration.WorkingDirectory, Is.EqualTo(DefaultEvaluatedWorkingDirectory));
+            Assert.That(this.Project.ActiveConfiguration.VSDebugConfiguration.Environment, Is.EqualTo(DefaultEvaluatedEnvironment));
         }
 
         #endregion Tests

--- a/VisualStudioAdapter/IVSDebugConfiguration.cs
+++ b/VisualStudioAdapter/IVSDebugConfiguration.cs
@@ -13,7 +13,11 @@ namespace VisualStudioAdapter
         /// <summary>
         /// Retrieves Working Directory
         /// </summary>
-        string WorkingDirectory { get; }       
-         
+        string WorkingDirectory { get; }
+
+        /// <summary>
+        /// Retrieves Environment
+        /// </summary>
+        string Environment { get; }
     }    
 }

--- a/VisualStudioAdapterShared/VSDebugConfiguration.cs
+++ b/VisualStudioAdapterShared/VSDebugConfiguration.cs
@@ -51,7 +51,18 @@ namespace VisualStudioAdapter.Shared
                 return this._configuration.Evaluate(setting.WorkingDirectory);
             }
         }
-        
+
+        /// <summary>
+        /// Evaluates 'Environment' from Visual Studio Configuration Properties
+        /// </summary>
+        public string Environment
+        {
+            get
+            {
+                VCDebugSettings setting = this._configuration.DebugSettings as VCDebugSettings;
+                return this._configuration.Evaluate(setting.Environment);
+            }
+        }
 
         #endregion IVSConfiguration
     }


### PR DESCRIPTION
Extracts the environment variables from the project's configuration property pages and uses these properties to instantiate the test environment.

Tackles one of the requests mentioned in issue #71.