### PR TITLE
Properly parse and format boost test context information

### DIFF
--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryError.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryError.cs
@@ -3,6 +3,8 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+using System.Linq;
+using System.Collections.Generic;
 using BoostTestAdapter.Utility;
 
 namespace BoostTestAdapter.Boost.Results.LogEntryTypes
@@ -15,12 +17,20 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         #region Constructors
 
         /// <summary>
+        /// Default constructor
+        /// </summary>
+        public LogEntryError()
+            : this(string.Empty)
+        {
+        }
+
+        /// <summary>
         /// Constructor accepting a detail message
         /// </summary>
         /// <param name="detail">detail message of type string</param>
         public LogEntryError(string detail)
+            : this(detail, null)
         {
-            this.Detail = detail;
         }
 
         /// <summary>
@@ -29,13 +39,31 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         /// <param name="detail">detail message of type string</param>
         /// <param name="source">Source file information related to this log message. May be null.</param>
         public LogEntryError(string detail, SourceFileInfo source)
+            : this(detail, source, Enumerable.Empty<string>())
+        {
+        }
+
+
+        /// <summary>
+        /// Constructor accepting a detail message, a SourceFileInfo object and error context frames
+        /// </summary>
+        /// <param name="detail">detail message of type string</param>
+        /// <param name="source">Source file information related to this log message. May be null.</param>
+        /// <param name="contextFrames">Error context frame information related to this error message. May be empty.</param>
+        public LogEntryError(string detail, SourceFileInfo source, IEnumerable<string> contextFrames)
             : base(source)
         {
             this.Detail = detail;
+            this.ContextFrames = contextFrames;
         }
 
         #endregion Constructors
 
+        /// <summary>
+        /// Context frame information.
+        /// </summary>
+        public IEnumerable<string> ContextFrames { get; set; }
+        
         /// <summary>
         /// returns a string with the description of the class
         /// </summary>

--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -204,6 +204,10 @@
     <EmbeddedResource Include="Resources\ReportsLogs\Empty\sample.test.log.xml" />
     <EmbeddedResource Include="Resources\ReportsLogs\Empty\sample.test.report.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\ReportsLogs\TestContext\ExampleBoostUnittest.exe.test.log.xml" />
+    <EmbeddedResource Include="Resources\ReportsLogs\TestContext\ExampleBoostUnittest.exe.test.report.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/BoostTestAdapterNunit/Resources/ReportsLogs/TestContext/ExampleBoostUnittest.exe.test.log.xml
+++ b/BoostTestAdapterNunit/Resources/ReportsLogs/TestContext/ExampleBoostUnittest.exe.test.log.xml
@@ -1,0 +1,57 @@
+<TestLog>
+    <TestSuite name="mytest">
+        <TestCase name="test1" file="c:\exampleboostunittest\source.cpp" line="25">
+            <Error file="c:/exampleboostunittest/source.cpp" line="19">
+                <![CDATA[check processor.op2(i, j) has failed]]>
+                <Context>
+                    <Frame>
+                        <![CDATA[With optimization level 1]]>
+                    </Frame>
+                    <Frame>
+                        <![CDATA[With parameter i = 1]]>
+                    </Frame>
+                    <Frame>
+                        <![CDATA[With parameter j = 0]]>
+                    </Frame>
+                </Context>
+            </Error>
+            <Error file="c:/exampleboostunittest/source.cpp" line="16">
+                <![CDATA[check processor.op1(i) has failed]]>
+                <Context>
+                    <Frame>
+                        <![CDATA[With optimization level 2]]>
+                    </Frame>
+                    <Frame>
+                        <![CDATA[With parameter i = 0]]>
+                    </Frame>
+                </Context>
+            </Error>
+            <Error file="c:/exampleboostunittest/source.cpp" line="16">
+                <![CDATA[check processor.op1(i) has failed]]>
+                <Context>
+                    <Frame>
+                        <![CDATA[With optimization level 2]]>
+                    </Frame>
+                    <Frame>
+                        <![CDATA[With parameter i = 1]]>
+                    </Frame>
+                </Context>
+            </Error>
+            <Error file="c:/exampleboostunittest/source.cpp" line="19">
+                <![CDATA[check processor.op2(i, j) has failed]]>
+                <Context>
+                    <Frame>
+                        <![CDATA[With optimization level 2]]>
+                    </Frame>
+                    <Frame>
+                        <![CDATA[With parameter i = 1]]>
+                    </Frame>
+                    <Frame>
+                        <![CDATA[With parameter j = 0]]>
+                    </Frame>
+                </Context>
+            </Error>
+            <TestingTime>4000</TestingTime>
+        </TestCase>
+    </TestSuite>
+</TestLog>

--- a/BoostTestAdapterNunit/Resources/ReportsLogs/TestContext/ExampleBoostUnittest.exe.test.report.xml
+++ b/BoostTestAdapterNunit/Resources/ReportsLogs/TestContext/ExampleBoostUnittest.exe.test.report.xml
@@ -1,0 +1,5 @@
+<TestResult>
+    <TestSuite name="mytest" result="failed" assertions_passed="5" assertions_failed="4" warnings_failed="0" expected_failures="0" test_cases_passed="0" test_cases_passed_with_warnings="0" test_cases_failed="1" test_cases_skipped="0" test_cases_aborted="0">
+        <TestCase name="test1" result="failed" assertions_passed="5" assertions_failed="4" warnings_failed="0" expected_failures="0"/>
+    </TestSuite>
+</TestResult>


### PR DESCRIPTION
When using `BOOST_TEST_CONTEXT` or `BOOST_TEST_INFO` (i.e. [Boost Test Contexts](http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/test_output/contexts.html)), the output was not properly formatted.

Updated parsing to take into consideration this information and also updated output formatting so that context information is properly formatted in the 'Output' tab.