### PR TITLE
Improve file-naming scheme

### DIFF
--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Utility\QualifiedNameBuilder.cs" />
     <Compile Include="Utility\ROTException.cs" />
     <Compile Include="Utility\SourceFileInfo.cs" />
+    <Compile Include="Utility\TemporaryFile.cs" />
     <Compile Include="Utility\TestRun.cs" />
     <Compile Include="Utility\VisualStudio\DefaultDiscoverySink.cs" />
     <Compile Include="Utility\VisualStudio\DefaultVisualStudioInstanceProvider.cs" />

--- a/BoostTestAdapter/BoostTestDiscoverer.cs
+++ b/BoostTestAdapter/BoostTestDiscoverer.cs
@@ -119,7 +119,7 @@ namespace BoostTestAdapter
             catch (Exception ex)
             {
                 Logger.Error("Exception caught while discovering tests: {0} ({1})", ex.Message, ex.HResult);
-                Logger.Error(ex.StackTrace);
+                Logger.Trace(ex.StackTrace);
             }
         }
     }

--- a/BoostTestAdapter/Discoverers/ExternalDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/ExternalDiscoverer.cs
@@ -188,7 +188,7 @@ namespace BoostTestAdapter.Discoverers
             catch(Exception ex)
             {
                 Logger.Error("Exception caught while reading xml file {0} ({1} -  {2})", path, ex.Message, ex.HResult);
-                Logger.Error(ex.StackTrace);
+                Logger.Trace(ex.StackTrace);
             }
             return null;
         }

--- a/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
@@ -129,7 +129,7 @@ namespace BoostTestAdapter.Discoverers
                 catch (Exception ex)
                 {
                     Logger.Error("Exception caught while discovering tests for {0} ({1} - {2})", source, ex.Message, ex.HResult);
-                    Logger.Error(ex.StackTrace);
+                    Logger.Trace(ex.StackTrace);
                 }
             }
         }

--- a/BoostTestAdapter/Discoverers/SourceCodeDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/SourceCodeDiscoverer.cs
@@ -170,7 +170,7 @@ namespace BoostTestAdapter.Discoverers
                                     Logger.Error(
                                             "Exception raised while discovering tests from \"{0}\" of project \"{1}\", ({2})",
                                             sourceFile, projectInfo.ProjectExe, ex.Message);
-                                    Logger.Error(ex.StackTrace);
+                                    Logger.Trace(ex.StackTrace);
                                 }
                             }
                         }

--- a/BoostTestAdapter/Utility/Logger.cs
+++ b/BoostTestAdapter/Utility/Logger.cs
@@ -131,6 +131,9 @@ namespace BoostTestAdapter.Utility
 #if TRACE
             // Represent a trace log as a regular info log for proper output
             Info(format, args);
+
+            // Persist the log information for later inspection
+            log4netLogger.Debug(string.Format(CultureInfo.InvariantCulture, format, args));
 #endif
         }
 

--- a/BoostTestAdapter/Utility/TemporaryFile.cs
+++ b/BoostTestAdapter/Utility/TemporaryFile.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.IO;
+
+namespace BoostTestAdapter.Utility
+{
+    /// <summary>
+    /// A temporary file representation which is deleted once disposed.
+    /// </summary>
+    class TemporaryFile : IDisposable
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="path">The path to the temporary file</param>
+        public TemporaryFile(string path)
+        {
+            this.Path = path;
+        }
+        
+        /// <summary>
+        /// Tries to delete the temporary file
+        /// </summary>
+        /// <returns>true if deletion is successful; false otherwise</returns>
+        private bool Delete()
+        {
+            if (!string.IsNullOrEmpty(this.Path) && File.Exists(this.Path))
+            {
+                File.Delete(this.Path);
+                return true;
+            }
+
+            return false;
+        }
+        
+        /// <summary>
+        /// Temporary file path
+        /// </summary>
+        public string Path { get; private set; }
+
+        #region IDisposable Support
+
+        private bool _disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    Delete();
+                }
+
+                _disposedValue = true;
+            }
+        }
+        
+        // This code added to correctly implement the disposable pattern.
+        void IDisposable.Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+        }
+
+        #endregion
+    }
+}

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -15,6 +15,16 @@ namespace BoostTestAdapterNunit
         #region Utility Methods
 
         /// <summary>
+        /// Generates a dummy fully qualified path for the provided filename
+        /// </summary>
+        /// <param name="filename">The filename to generate a fully qualified version for it</param>
+        /// <returns>A dummy fully qualified path</returns>
+        private static string GenerateFullyQualifiedPath(string filename)
+        {
+            return @"C:\Temp\" + filename;
+        }
+        
+        /// <summary>
         /// Generates a command line args instance with pre-determined values.
         /// </summary>
         /// <returns>A new BoostTestRunnerCommandLineArgs instance populated with pre-determined values.</returns>
@@ -27,19 +37,19 @@ namespace BoostTestAdapterNunit
 
             args.LogFormat = OutputFormat.XML;
             args.LogLevel = LogLevel.TestSuite;
-            args.LogFile = Path.Combine(Path.GetTempPath(), "log.xml");
+            args.LogFile = GenerateFullyQualifiedPath("log.xml");
 
             args.ReportFormat = OutputFormat.XML;
             args.ReportLevel = ReportLevel.Detailed;
-            args.ReportFile = Path.Combine(Path.GetTempPath(), "report.xml");
+            args.ReportFile = GenerateFullyQualifiedPath("report.xml");
 
             args.DetectMemoryLeaks = 0;
 
             args.CatchSystemErrors = false;
             args.DetectFPExceptions = true;
 
-            args.StandardOutFile = Path.Combine(Path.GetTempPath(), "stdout.log");
-            args.StandardErrorFile = Path.Combine(Path.GetTempPath(), "stderr.log");
+            args.StandardOutFile = GenerateFullyQualifiedPath("stdout.log");
+            args.StandardErrorFile = GenerateFullyQualifiedPath("stderr.log");
 
             return args;
         }
@@ -73,10 +83,10 @@ namespace BoostTestAdapterNunit
             BoostTestRunnerCommandLineArgs args = GenerateCommandLineArgs();
             // serge: boost 1.60 requires uppercase input
             Assert.That(args.ToString(), Is.EqualTo("\"--run_test=test,suite/*\" \"--catch_system_errors=no\" \"--log_format=XML\" \"--log_level=test_suite\" \"--log_sink="
-                + Path.Combine(Path.GetTempPath(), "log.xml") + "\" \"--report_format=XML\" \"--report_level=detailed\" \"--report_sink="
-                + Path.Combine(Path.GetTempPath(), "report.xml") + "\" \"--detect_memory_leak=0\" \"--detect_fp_exceptions=yes\" > \"" 
-                + Path.Combine(Path.GetTempPath(), "stdout.log") + "\" 2> \""
-                + Path.Combine(Path.GetTempPath(), "stderr.log") + "\""));
+                + GenerateFullyQualifiedPath("log.xml") + "\" \"--report_format=XML\" \"--report_level=detailed\" \"--report_sink="
+                + GenerateFullyQualifiedPath("report.xml") + "\" \"--detect_memory_leak=0\" \"--detect_fp_exceptions=yes\" > \"" 
+                + GenerateFullyQualifiedPath("stdout.log") + "\" 2> \""
+                + GenerateFullyQualifiedPath("stderr.log") + "\""));
         }
 
         /// <summary>
@@ -117,6 +127,30 @@ namespace BoostTestAdapterNunit
             Assert.That(args.ListContent, Is.EqualTo(clone.ListContent));
 
             Assert.That(args.ToString(), Is.EqualTo(clone.ToString()));
+        }
+
+        /// <summary>
+        /// Based on how a file path is provided, the class tries to root the path if possible
+        /// 
+        /// Test aims:
+        ///     - The file path is rooted if possible.
+        /// </summary>
+        [Test]
+        public void FilePaths()
+        {
+            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
+
+            args.LogFile = "log.xml";
+            Assert.That(args.LogFile, Is.EqualTo("log.xml"));
+            Assert.That(args.ToString(), Is.EqualTo("\"--log_sink=log.xml\""));
+
+            args.WorkingDirectory = @"C:\";
+            Assert.That(args.LogFile, Is.EqualTo(@"C:\log.xml"));
+            Assert.That(args.ToString(), Is.EqualTo("\"--log_sink=C:\\log.xml\""));
+
+            args.LogFile = @"D:\Temp\log.xml";
+            Assert.That(args.LogFile, Is.EqualTo(@"D:\Temp\log.xml"));
+            Assert.That(args.ToString(), Is.EqualTo("\"--log_sink=D:\\Temp\\log.xml\""));
         }
 
         #endregion Tests


### PR DESCRIPTION
Slightly improves the file-naming scheme to possibly allow for parallel execution. Also improves temporary file cleanup.

Additionaly, `BoostTestRunnerCommandLineArgs` unit tests have been slightly improved by taking into consideration @daniel-kun's review comments from PR #96.