### PR TITLE
Allow Standard Output and Standard Error Redirection to be Configurable

### DIFF
--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -445,9 +445,9 @@ namespace BoostTestAdapter
             args.ReportFormat = OutputFormat.XML;
             args.ReportLevel = ReportLevel.Detailed;
             args.ReportFile = Path.Combine(Path.GetTempPath(), SanitizeFileName(filename + FileExtensions.ReportFile));
-
-            args.StandardOutFile = Path.Combine(Path.GetTempPath(), SanitizeFileName(filename + FileExtensions.StdOutFile));
-            args.StandardErrorFile = Path.Combine(Path.GetTempPath(), SanitizeFileName(filename + FileExtensions.StdErrFile));
+            
+            args.StandardOutFile = ((settings.EnableStdOutRedirection) ? Path.Combine(Path.GetTempPath(), SanitizeFileName(filename + FileExtensions.StdOutFile)) : null);
+            args.StandardErrorFile = ((settings.EnableStdErrRedirection) ? Path.Combine(Path.GetTempPath(), SanitizeFileName(filename + FileExtensions.StdErrFile)) : null);
 
             return args;
         }

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -48,6 +48,10 @@ namespace BoostTestAdapter.Settings
             this.UseListContent = false;
 
             this.WorkingDirectory = null;
+
+            this.EnableStdOutRedirection = true;
+
+            this.EnableStdErrRedirection = true;
         }
 
         #region Properties
@@ -129,7 +133,12 @@ namespace BoostTestAdapter.Settings
 
         [DefaultValue(null)]
         public string WorkingDirectory { get; set; }
+        
+        [DefaultValue(true)]
+        public bool EnableStdOutRedirection { get; set; }
 
+        [DefaultValue(true)]
+        public bool EnableStdErrRedirection { get; set; }
 
         #endregion Serialisable Fields
 

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -54,6 +54,9 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.CatchSystemErrors, Is.True);
             Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestCase));
             Assert.That(settings.UseListContent, Is.False);
+            Assert.That(settings.WorkingDirectory, Is.Null);
+            Assert.That(settings.EnableStdOutRedirection, Is.True);
+            Assert.That(settings.EnableStdErrRedirection, Is.True);
         }
 
         /// <summary>


### PR DESCRIPTION
Provide the ability to configure standard stream redirection via `<EnableStdOutRedirection>` and `<EnableStdErrRedirection>`.

Some test programs may not play well with our redirection mechanism so provide the ability to disable it in such cases.