### PR TITLE
Parse Memory Leak Information from Standard Error (and Standard Output)

### DIFF
--- a/BoostTestAdapter/Boost/Results/BoostConsoleOutputBase.cs
+++ b/BoostTestAdapter/Boost/Results/BoostConsoleOutputBase.cs
@@ -1,0 +1,267 @@
+﻿// (C) Copyright ETAS 2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+using System.IO;
+using System.Text.RegularExpressions;
+using BoostTestAdapter.Boost.Results.LogEntryTypes;
+
+namespace BoostTestAdapter.Boost.Results
+{
+    /// <summary>
+    /// Console output (standard output/error) results as emitted by Boost Test executables
+    /// </summary>
+    public abstract class BoostConsoleOutputBase : BoostTestResultOutputBase
+    {
+        #region Constructors
+
+        /// <summary>
+        /// Constructor accepting a path to the external file
+        /// </summary>
+        /// <param name="path">The path to an external file. File will be opened on construction.</param>
+        protected BoostConsoleOutputBase(string path)
+            : base(path)
+        {
+            this.FailTestOnMemoryLeak = false;
+        }
+
+        /// <summary>
+        /// Constructor accepting a stream to the file contents
+        /// </summary>
+        /// <param name="stream">The file content stream.</param>
+        protected BoostConsoleOutputBase(Stream stream)
+            : base(stream)
+        {
+            this.FailTestOnMemoryLeak = false;
+        }
+
+        #endregion Constructors
+
+        #region Properties
+
+        /// <summary>
+        /// Determines wheter or not a test should fail if a memory leak is detected within the output
+        /// </summary>
+        public bool FailTestOnMemoryLeak { get; set; }
+
+        #endregion Properties
+
+        #region IBoostOutputParser
+
+        /// <summary>
+        /// Processes the standard output and populates the relevant test result data of the referenced collection
+        /// </summary>
+        /// <param name="collection">test result collection where the leak information data will be inserted at</param>
+        public override void Parse(TestResultCollection collection)
+        {
+            using (StreamReader reader = new StreamReader(this.InputStream))
+            {
+                string strConsoleOutput = reader.ReadToEnd();
+
+                //the below regex is intended to only to "detect" if any memory leaks are present. Note that any console output printed by the test generally appears before the memory leaks dump.
+                Regex regexObj = new Regex(@"Detected\smemory\sleaks!\nDumping objects\s->\n(.*)Object dump complete.", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Multiline);
+                Match outputMatch = regexObj.Match(strConsoleOutput);
+
+                //leak has been detected
+                if (outputMatch.Success)
+                {
+                    RegisterMemoryLeak(outputMatch.Groups[1].Value, collection);
+                }
+
+                // Extract non-memory leak output
+                string output = strConsoleOutput.Substring(0, ((outputMatch.Success) ? outputMatch.Index : strConsoleOutput.Length));
+                RegisterMessages(output, collection);
+            }
+        }
+
+        #endregion IBoostOutputParser
+
+        /// <summary>
+        /// Registers the provided memory leak string representation within the test collection
+        /// </summary>
+        /// <param name="leakInformation">The full memory leak information</param>
+        /// <param name="collection">The test collection in which to place memory leak entries</param>
+        private void RegisterMemoryLeak(string leakInformation, TestResultCollection collection)
+        {
+            foreach (TestResult result in collection)
+            {
+                if (this.FailTestOnMemoryLeak)
+                {
+                    result.Result = TestResultType.Failed;
+                }
+
+                Regex regexLeakInformation = new Regex(@"(?:([\\:\w\rA-z.]*?)([\w\d.]*)\((\d{1,})\)\s:\s)?\{(\d{1,})\}[\w\s\d]*,\s(\d{1,})[\s\w.]*\n(.*?)(?=$|(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d)", RegexOptions.IgnoreCase | RegexOptions.Singleline);   //the old one wasRegex regexLeakInformation = new Regex(@"^(.*\\)(.*?)\((\d{1,})\).*?{(\d{1,})}.*?(\d{1,})\sbyte", RegexOptions.IgnoreCase | RegexOptions.Multiline);
+                /*
+
+                 The same regex works for when the complete file path along with the line number are reported in the console output such as in the below sample output
+
+                 d:\hwa\dev\svn\boostunittestadapterdev\branches\tempbugfixing\sample\boostunittest\boostunittest2\adapterbugs.cpp(58) : {869} normal block at 0x00A88A58, 4 bytes long.
+                    Data: <    > CD CD CD CD
+                 d:\hwa\dev\svn\boostunittestadapterdev\branches\tempbugfixing\sample\boostunittest\boostunittest2\adapterbugs.cpp(55) : {868} normal block at 0x00A88788, 4 bytes long.
+                    Data: <    > F5 01 00 00
+
+                 and also when this information is not reported such as in the below sample output
+
+                {869} normal block at 0x005E8998, 4 bytes long.
+                 Data: <    > CD CD CD CD
+                {868} normal block at 0x005E8848, 4 bytes long.
+                 Data: <    > F5 01 00 00
+
+                 */
+
+                #region regexLeakInformation
+
+                // (?:([\\:\w\rA-z.]*?)([\w\d.]*)\((\d{1,})\)\s:\s)?\{(\d{1,})\}[\w\s\d]*,\s(\d{1,})[\s\w.]*\n(.*?)(?=$|(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d)
+                //
+                // Options: Case insensitive; Exact spacing; Dot matches line breaks; ^$ don't match at line breaks; Numbered capture
+                //
+                // Match the regular expression below «(?:([\\:\w\rA-z.]*?)([\w\d.]*)\((\d{1,})\)\s:\s)?»
+                //    Between zero and one times, as many times as possible, giving back as needed (greedy) «?»
+                //    Match the regex below and capture its match into backreference number 1 «([\\:\w\rA-z.]*?)»
+                //       Match a single character present in the list below «[\\:\w\rA-z.]*?»
+                //          Between zero and unlimited times, as few times as possible, expanding as needed (lazy) «*?»
+                //          The backslash character «\\»
+                //          The literal character “:” «:»
+                //          A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
+                //          The carriage return character «\r»
+                //          A character in the range between “A” and “z” (case insensitive) «A-z»
+                //          The literal character “.” «.»
+                //    Match the regex below and capture its match into backreference number 2 «([\w\d.]*)»
+                //       Match a single character present in the list below «[\w\d.]*»
+                //          Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
+                //          A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
+                //          A “digit” (0–9 in any Unicode script) «\d»
+                //          The literal character “.” «.»
+                //    Match the character “(” literally «\(»
+                //    Match the regex below and capture its match into backreference number 3 «(\d{1,})»
+                //       Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
+                //          Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
+                //    Match the character “)” literally «\)»
+                //    Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
+                //    Match the character “:” literally «:»
+                //    Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
+                // Match the character “{” literally «\{»
+                // Match the regex below and capture its match into backreference number 4 «(\d{1,})»
+                //    Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
+                //       Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
+                // Match the character “}” literally «\}»
+                // Match a single character present in the list below «[\w\s\d]*»
+                //    Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
+                //    A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
+                //    A “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
+                //    A “digit” (0–9 in any Unicode script) «\d»
+                // Match the character “,” literally «,»
+                // Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
+                // Match the regex below and capture its match into backreference number 5 «(\d{1,})»
+                //    Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
+                //       Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
+                // Match a single character present in the list below «[\s\w.]*»
+                //    Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
+                //    A “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
+                //    A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
+                //    The literal character “.” «.»
+                // Match the line feed character «\n»
+                // Match the regex below and capture its match into backreference number 6 «(.*?)»
+                //    Match any single character «.*?»
+                //       Between zero and unlimited times, as few times as possible, expanding as needed (lazy) «*?»
+                // Assert that the regex below can be matched, starting at this position (positive lookahead) «(?=$|(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d)»
+                //    Match this alternative (attempting the next alternative only if this one fails) «$»
+                //       Assert position at the end of the string, or before the line break at the end of the string, if any (line feed) «$»
+                //    Or match this alternative (the entire group fails if this one fails to match) «(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d»
+                //       Match the regular expression below «(?:[\\\w.:]*\(\d{1,}\)\s:\s)?»
+                //          Between zero and one times, as many times as possible, giving back as needed (greedy) «?»
+                //          Match a single character present in the list below «[\\\w.:]*»
+                //             Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
+                //             The backslash character «\\»
+                //             A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
+                //             A single character from the list “.:” «.:»
+                //          Match the character “(” literally «\(»
+                //          Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
+                //             Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
+                //          Match the character “)” literally «\)»
+                //          Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
+                //          Match the character “:” literally «:»
+                //          Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
+                //       Match the character “{” literally «\{»
+                //       Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
+                //          Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
+                //       Match a single character that is a “digit” (0–9 in any Unicode script) «\d»
+
+                #endregion regexLeakInformation
+
+                Match matchLeakInformation = regexLeakInformation.Match(leakInformation);
+                while (matchLeakInformation.Success)
+                {
+                    LogEntryMemoryLeak leak = new LogEntryMemoryLeak();
+
+                    result.LogEntries.Add(leak);
+
+                    //Capturing group 1,2 and 3 will have the 'Success' property false in case the C++ new operator has not been replaced via the macro
+
+                    // Temporary variable used to try and parse unsigned integer values;
+                    uint value = 0;
+
+                    if (matchLeakInformation.Groups[1].Success && matchLeakInformation.Groups[2].Success && matchLeakInformation.Groups[3].Success)
+                    {
+                        leak.LeakSourceFilePath = matchLeakInformation.Groups[1].Value;
+
+                        leak.LeakSourceFileName = matchLeakInformation.Groups[2].Value;
+
+                        if (uint.TryParse(matchLeakInformation.Groups[3].Value, out value))
+                        {
+                            leak.LeakLineNumber = value;
+                        }
+
+                        leak.LeakSourceFileAndLineNumberReportingActive = true;
+                    }
+                    else
+                    {
+                        leak.LeakSourceFileAndLineNumberReportingActive = false;
+                    }
+
+                    if (uint.TryParse(matchLeakInformation.Groups[4].Value, out value))
+                    {
+                        leak.LeakMemoryAllocationNumber = value;
+                    }
+
+                    if (uint.TryParse(matchLeakInformation.Groups[5].Value, out value))
+                    {
+                        leak.LeakSizeInBytes = value;
+                    }
+
+                    leak.LeakLeakedDataContents = matchLeakInformation.Groups[6].Value;
+
+                    matchLeakInformation = matchLeakInformation.NextMatch();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers any-and-all console output messages with all tests within the collection
+        /// </summary>
+        /// <param name="output">The console output</param>
+        /// <param name="collection">The test collection in which to place console log entries</param>
+        private void RegisterMessages(string output, TestResultCollection collection)
+        {
+            if (!string.IsNullOrEmpty(output))
+            {
+                // Attach the console output to each TestCase result in the collection
+                // since we cannot distinguish to which TestCase (in case multiple TestCases are registered)
+                // the output is associated with.
+                foreach (TestResult result in collection)
+                {
+                    // Consider the whole console contents as 1 entry.
+                    result.LogEntries.Add(CreateLogEntry(output));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Factory function which creates a LogEntry instance for the console message output
+        /// </summary>
+        /// <param name="message">The console output message</param>
+        /// <returns>A LogEntry representation of the console message output</returns>
+        protected abstract LogEntry CreateLogEntry(string message);
+    }
+}

--- a/BoostTestAdapter/Boost/Results/BoostStandardError.cs
+++ b/BoostTestAdapter/Boost/Results/BoostStandardError.cs
@@ -11,7 +11,7 @@ namespace BoostTestAdapter.Boost.Results
     /// <summary>
     /// Standard Error as emitted by Boost Test executables
     /// </summary>
-    public class BoostStandardError : BoostTestResultOutputBase
+    public class BoostStandardError : BoostConsoleOutputBase
     {
         /// <summary>
         /// Constructor accepting a path to the external file
@@ -30,33 +30,14 @@ namespace BoostTestAdapter.Boost.Results
             : base(stream)
         {
         }
+        
+        #region BoostConsoleOutputBase
 
-        #region BoostTestResultOutputBase
-
-        public override void Parse(TestResultCollection collection)
+        protected override LogEntry CreateLogEntry(string message)
         {
-            Utility.Code.Require(collection, "collection");
-
-            string err = null;
-
-            using (StreamReader reader = new StreamReader(this.InputStream))
-            {
-                err = reader.ReadToEnd();
-            }
-
-            if (!string.IsNullOrEmpty(err))
-            {
-                // Attach the stderr output to each TestCase result in the collection
-                // since we cannot distinguish to which TestCase (in case multiple TestCases are registered)
-                // the output is associated with.
-                foreach (TestResult result in collection)
-                {
-                    // Consider the whole standard error contents as 1 entry.
-                    result.LogEntries.Add(new LogEntryStandardErrorMessage(err));
-                }
-            }
+            return new LogEntryStandardErrorMessage(message);
         }
 
-        #endregion BoostTestResultOutputBase
+        #endregion BoostConsoleOutputBase        
     }
 }

--- a/BoostTestAdapter/Boost/Results/BoostStandardOutput.cs
+++ b/BoostTestAdapter/Boost/Results/BoostStandardOutput.cs
@@ -4,7 +4,6 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 using System.IO;
-using System.Text.RegularExpressions;
 using BoostTestAdapter.Boost.Results.LogEntryTypes;
 
 namespace BoostTestAdapter.Boost.Results
@@ -12,7 +11,7 @@ namespace BoostTestAdapter.Boost.Results
     /// <summary>
     /// Standard Output as emitted by Boost Test executables
     /// </summary>
-    public class BoostStandardOutput : BoostTestResultOutputBase
+    public class BoostStandardOutput : BoostConsoleOutputBase
     {
         #region Constructors
 
@@ -23,7 +22,6 @@ namespace BoostTestAdapter.Boost.Results
         public BoostStandardOutput(string path)
             : base(path)
         {
-            this.FailTestOnMemoryLeak = false;
         }
 
         /// <summary>
@@ -33,214 +31,17 @@ namespace BoostTestAdapter.Boost.Results
         public BoostStandardOutput(Stream stream)
             : base(stream)
         {
-            this.FailTestOnMemoryLeak = false;
         }
 
         #endregion Constructors
 
-        #region Properties
+        #region BoostConsoleOutputBase
 
-        public bool FailTestOnMemoryLeak { get; set; }
-
-        #endregion Properties
-
-        #region IBoostOutputParser
-
-        /// <summary>
-        /// Processes the standard output and populates the relevant test result data of the referenced collection
-        /// </summary>
-        /// <param name="collection">test result collection where the leak information data will be inserted at</param>
-        public override void Parse(TestResultCollection collection)
+        protected override LogEntry CreateLogEntry(string message)
         {
-            string strConsoleOutput = StreamToString(this.InputStream);
-
-            //the below regex is intended to only to "detect" if any memory leaks are present. Note that any console output printed by the test generally appears before the memory leaks dump.
-            Regex regexObj = new Regex(@"Detected\smemory\sleaks!\nDumping objects\s->\n(.*)Object dump complete.", RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Multiline);
-            Match outputMatch = regexObj.Match(strConsoleOutput);
-
-            //leak has been detected
-            if (outputMatch.Success)
-            {
-                RegisterMemoryLeak(outputMatch.Groups[1].Value, collection);
-            }
-
-            // Extract non-memory leak output
-            string output = strConsoleOutput.Substring(0, ((outputMatch.Success) ? outputMatch.Index : strConsoleOutput.Length));
-            RegisterStandardOutputMessage(output, collection);
+            return new LogEntryStandardOutputMessage(message);
         }
 
-        #endregion IBoostOutputParser
-
-        private void RegisterMemoryLeak(string leakInformation, TestResultCollection collection)
-        {
-            foreach (TestResult result in collection)
-            {
-                if (this.FailTestOnMemoryLeak)
-                {
-                    result.Result = TestResultType.Failed;
-                }
-
-                Regex regexLeakInformation = new Regex(@"(?:([\\:\w\rA-z.]*?)([\w\d.]*)\((\d{1,})\)\s:\s)?\{(\d{1,})\}[\w\s\d]*,\s(\d{1,})[\s\w.]*\n(.*?)(?=$|(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d)", RegexOptions.IgnoreCase | RegexOptions.Singleline);   //the old one wasRegex regexLeakInformation = new Regex(@"^(.*\\)(.*?)\((\d{1,})\).*?{(\d{1,})}.*?(\d{1,})\sbyte", RegexOptions.IgnoreCase | RegexOptions.Multiline);
-                /*
-
-                 The same regex works for when the complete file path along with the line number are reported in the console output such as in the below sample output
-
-                 d:\hwa\dev\svn\boostunittestadapterdev\branches\tempbugfixing\sample\boostunittest\boostunittest2\adapterbugs.cpp(58) : {869} normal block at 0x00A88A58, 4 bytes long.
-                    Data: <    > CD CD CD CD
-                 d:\hwa\dev\svn\boostunittestadapterdev\branches\tempbugfixing\sample\boostunittest\boostunittest2\adapterbugs.cpp(55) : {868} normal block at 0x00A88788, 4 bytes long.
-                    Data: <    > F5 01 00 00
-
-                 and also when this information is not reported such as in the below sample output
-
-                {869} normal block at 0x005E8998, 4 bytes long.
-                 Data: <    > CD CD CD CD
-                {868} normal block at 0x005E8848, 4 bytes long.
-                 Data: <    > F5 01 00 00
-
-                 */
-
-                #region regexLeakInformation
-
-                // (?:([\\:\w\rA-z.]*?)([\w\d.]*)\((\d{1,})\)\s:\s)?\{(\d{1,})\}[\w\s\d]*,\s(\d{1,})[\s\w.]*\n(.*?)(?=$|(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d)
-                //
-                // Options: Case insensitive; Exact spacing; Dot matches line breaks; ^$ don't match at line breaks; Numbered capture
-                //
-                // Match the regular expression below «(?:([\\:\w\rA-z.]*?)([\w\d.]*)\((\d{1,})\)\s:\s)?»
-                //    Between zero and one times, as many times as possible, giving back as needed (greedy) «?»
-                //    Match the regex below and capture its match into backreference number 1 «([\\:\w\rA-z.]*?)»
-                //       Match a single character present in the list below «[\\:\w\rA-z.]*?»
-                //          Between zero and unlimited times, as few times as possible, expanding as needed (lazy) «*?»
-                //          The backslash character «\\»
-                //          The literal character “:” «:»
-                //          A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
-                //          The carriage return character «\r»
-                //          A character in the range between “A” and “z” (case insensitive) «A-z»
-                //          The literal character “.” «.»
-                //    Match the regex below and capture its match into backreference number 2 «([\w\d.]*)»
-                //       Match a single character present in the list below «[\w\d.]*»
-                //          Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
-                //          A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
-                //          A “digit” (0–9 in any Unicode script) «\d»
-                //          The literal character “.” «.»
-                //    Match the character “(” literally «\(»
-                //    Match the regex below and capture its match into backreference number 3 «(\d{1,})»
-                //       Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
-                //          Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
-                //    Match the character “)” literally «\)»
-                //    Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
-                //    Match the character “:” literally «:»
-                //    Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
-                // Match the character “{” literally «\{»
-                // Match the regex below and capture its match into backreference number 4 «(\d{1,})»
-                //    Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
-                //       Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
-                // Match the character “}” literally «\}»
-                // Match a single character present in the list below «[\w\s\d]*»
-                //    Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
-                //    A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
-                //    A “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
-                //    A “digit” (0–9 in any Unicode script) «\d»
-                // Match the character “,” literally «,»
-                // Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
-                // Match the regex below and capture its match into backreference number 5 «(\d{1,})»
-                //    Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
-                //       Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
-                // Match a single character present in the list below «[\s\w.]*»
-                //    Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
-                //    A “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
-                //    A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
-                //    The literal character “.” «.»
-                // Match the line feed character «\n»
-                // Match the regex below and capture its match into backreference number 6 «(.*?)»
-                //    Match any single character «.*?»
-                //       Between zero and unlimited times, as few times as possible, expanding as needed (lazy) «*?»
-                // Assert that the regex below can be matched, starting at this position (positive lookahead) «(?=$|(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d)»
-                //    Match this alternative (attempting the next alternative only if this one fails) «$»
-                //       Assert position at the end of the string, or before the line break at the end of the string, if any (line feed) «$»
-                //    Or match this alternative (the entire group fails if this one fails to match) «(?:[\\\w.:]*\(\d{1,}\)\s:\s)?\{\d{1,}\d»
-                //       Match the regular expression below «(?:[\\\w.:]*\(\d{1,}\)\s:\s)?»
-                //          Between zero and one times, as many times as possible, giving back as needed (greedy) «?»
-                //          Match a single character present in the list below «[\\\w.:]*»
-                //             Between zero and unlimited times, as many times as possible, giving back as needed (greedy) «*»
-                //             The backslash character «\\»
-                //             A “word character” (Unicode; any letter or ideograph, digit, connector punctuation) «\w»
-                //             A single character from the list “.:” «.:»
-                //          Match the character “(” literally «\(»
-                //          Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
-                //             Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
-                //          Match the character “)” literally «\)»
-                //          Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
-                //          Match the character “:” literally «:»
-                //          Match a single character that is a “whitespace character” (any Unicode separator, tab, line feed, carriage return, vertical tab, form feed, next line) «\s»
-                //       Match the character “{” literally «\{»
-                //       Match a single character that is a “digit” (0–9 in any Unicode script) «\d{1,}»
-                //          Between one and unlimited times, as many times as possible, giving back as needed (greedy) «{1,}»
-                //       Match a single character that is a “digit” (0–9 in any Unicode script) «\d»
-
-                #endregion regexLeakInformation
-
-                Match matchLeakInformation = regexLeakInformation.Match(leakInformation);
-                while (matchLeakInformation.Success)
-                {
-                    LogEntryMemoryLeak leak = new LogEntryMemoryLeak();
-
-                    result.LogEntries.Add(leak);
-
-                    //Capturing group 1,2 and 3 will have the 'Success' property false in case the C++ new operator has not been replaced via the macro
-
-                    // Temporary variable used to try and parse unsigned integer values;
-                    uint value = 0;
-
-                    if (matchLeakInformation.Groups[1].Success && matchLeakInformation.Groups[2].Success && matchLeakInformation.Groups[3].Success)
-                    {
-                        leak.LeakSourceFilePath = matchLeakInformation.Groups[1].Value;
-
-                        leak.LeakSourceFileName = matchLeakInformation.Groups[2].Value;
-
-                        if (uint.TryParse(matchLeakInformation.Groups[3].Value, out value))
-                        {
-                            leak.LeakLineNumber = value;
-                        }
-
-                        leak.LeakSourceFileAndLineNumberReportingActive = true;
-                    }
-                    else
-                    {
-                        leak.LeakSourceFileAndLineNumberReportingActive = false;
-                    }
-
-                    if (uint.TryParse(matchLeakInformation.Groups[4].Value, out value))
-                    {
-                        leak.LeakMemoryAllocationNumber = value;
-                    }
-
-                    if (uint.TryParse(matchLeakInformation.Groups[5].Value, out value))
-                    {
-                        leak.LeakSizeInBytes = value;
-                    }
-
-                    leak.LeakLeakedDataContents = matchLeakInformation.Groups[6].Value;
-
-                    matchLeakInformation = matchLeakInformation.NextMatch();
-                }   
-            }
-        }
-
-        private static void RegisterStandardOutputMessage(string output, TestResultCollection collection)
-        {
-            if (!string.IsNullOrEmpty(output))
-            {
-                foreach (TestResult result in collection)
-                {
-                    result.LogEntries.Add(new LogEntryStandardOutputMessage(output));
-                }
-            }
-        }
-
-        private static string StreamToString(Stream stream)
-        {
-            StreamReader reader = new StreamReader(stream);
-            return reader.ReadToEnd();
-        }
+        #endregion BoostConsoleOutputBase
     }
 }

--- a/BoostTestAdapter/Boost/Results/TestResultCollection.cs
+++ b/BoostTestAdapter/Boost/Results/TestResultCollection.cs
@@ -101,7 +101,7 @@ namespace BoostTestAdapter.Boost.Results
                     GetReportParser(args),
                     GetLogParser(args),
                     GetStandardOutput(args, settings),
-                    GetStandardError(args)
+                    GetStandardError(args, settings)
                 };
 
                 Parse(parsers);
@@ -200,12 +200,16 @@ namespace BoostTestAdapter.Boost.Results
         /// Factory method which provides the standard error IBoostTestResultOutput based on the provided BoostTestRunnerCommandLineArgs and BoostTestAdapterSettings
         /// </summary>
         /// <param name="args">The command line args which were used to generate the test results</param>
+        /// <param name="settings">The run time settings which were used to generate the test results</param>
         /// <returns>An IBoostTestResultOutput or null if one cannot be identified from the provided arguments</returns>
-        private static IBoostTestResultOutput GetStandardError(BoostTestRunnerCommandLineArgs args)
+        private static IBoostTestResultOutput GetStandardError(BoostTestRunnerCommandLineArgs args, BoostTestAdapterSettings settings)
         {
             if ((!string.IsNullOrEmpty(args.StandardErrorFile)) && (File.Exists(args.StandardErrorFile)))
             {
-                return new BoostStandardError(args.StandardErrorFile);
+                return new BoostStandardError(args.StandardErrorFile)
+                {
+                    FailTestOnMemoryLeak = settings.FailTestOnMemoryLeak
+                };
             }
 
             return null;

--- a/BoostTestAdapter/Boost/Test/TestFrameworkDOTDeserialiser.cs
+++ b/BoostTestAdapter/Boost/Test/TestFrameworkDOTDeserialiser.cs
@@ -262,6 +262,8 @@ namespace BoostTestAdapter.Boost.Test
             /// <returns>An enumeration of all key-value pairs present in the provided attr_list</returns>
             private static IEnumerable<KeyValuePair<string, string>> GetKeyValuePairs(DOTParser.Attr_listContext attr_list)
             {
+                // NOTE Refer to DOT grammar; an 'attr_list' is composed of an 'a_list', which is composed of multiple 'id's
+
                 if (attr_list != null)
                 {
                     var a_lists = attr_list.a_list();
@@ -273,6 +275,8 @@ namespace BoostTestAdapter.Boost.Test
 
                             int id = 0;
                             int idCount = a_list.id().Length;
+
+                            // Try to identify the id() list as a list of 'id' = 'id' tuples
 
                             while (id < idCount)
                             {
@@ -287,6 +291,7 @@ namespace BoostTestAdapter.Boost.Test
                                     yield return new KeyValuePair<string, string>(lhs.GetText(), a_list.id()[id + 1].GetText());
                                     id += 2;
                                 }
+                                // Else provide the identifier a single item
                                 else
                                 {
                                     yield return new KeyValuePair<string, string>(lhs.GetText(), null);
@@ -329,10 +334,15 @@ namespace BoostTestAdapter.Boost.Test
             /// <returns>unit</returns>
             private static T PopulateTestUnit<T>(TestUnitInfo info, T unit) where T : TestUnit
             {
-                if (!string.IsNullOrEmpty(info.id))
+                if ((!string.IsNullOrEmpty(info.id)) && (info.id.Length > 2))
                 {
                     // Remove the 'tu' prefix from the test unit string ID
-                    unit.Id = int.Parse(info.id.Substring(2), CultureInfo.InvariantCulture);
+
+                    int id = 0;
+                    if (int.TryParse(info.id.Substring(2), NumberStyles.Integer, CultureInfo.InvariantCulture, out id))
+                    {
+                        unit.Id = id;
+                    }
                 }
 
                 unit.Source = info.SourceInfo;

--- a/BoostTestAdapter/BoostTestAdapter.csproj
+++ b/BoostTestAdapter/BoostTestAdapter.csproj
@@ -86,6 +86,7 @@
     <Compile Include="BoostTestExecutor.cs" />
     <Compile Include="Boost\Results\BoostStandardError.cs" />
     <Compile Include="Boost\Results\BoostStandardOutput.cs" />
+    <Compile Include="Boost\Results\BoostConsoleOutputBase.cs" />
     <Compile Include="Boost\Results\BoostTestResultOutputBase.cs" />
     <Compile Include="Boost\Results\BoostTestResultXMLOutput.cs" />
     <Compile Include="Boost\Results\BoostXmlLog.cs" />

--- a/BoostTestAdapter/Utility/VisualStudio/DefaultVisualStudioInstanceProvider.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/DefaultVisualStudioInstanceProvider.cs
@@ -39,7 +39,7 @@ namespace BoostTestAdapter.Utility.VisualStudio
 
                 DTEInstance dte = GetSolutionObject(parentProcessId);
 
-                if ((dte != null) && (dte.DTE != null))
+                if (dte?.DTE != null)
                 {
                     switch (dte.Version)
                     {

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -132,6 +132,7 @@
     <EmbeddedResource Include="Resources\ListContentDOT\sample.3.list.content.gv" />
     <EmbeddedResource Include="Resources\ListContentDOT\sample.list.content.gv" />
     <EmbeddedResource Include="Resources\ListContentDOT\sample.8.list.content.gv" />
+    <EmbeddedResource Include="Resources\ReportsLogs\MemoryLeakTest\sample.test.stderr.log" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\CppSources\BoostFixtureTestCase.cpp" />

--- a/BoostTestAdapterNunit/Resources/ReportsLogs/MemoryLeakTest/sample.test.stderr.log
+++ b/BoostTestAdapterNunit/Resources/ReportsLogs/MemoryLeakTest/sample.test.stderr.log
@@ -1,0 +1,7 @@
+Detected memory leaks!
+Dumping objects ->
+{837} normal block at 0x00BD2D60, 8 bytes long.
+ Data: <        > 98 D5 D9 00 00 00 00 00 
+{836} normal block at 0x00D9D598, 32 bytes long.
+ Data: <`-  Leak...     > 60 2D BD 00 4C 65 61 6B 2E 2E 2E 00 CD CD CD CD 
+Object dump complete.


### PR DESCRIPTION
- Share memory leak detection logic between standard error and standard output test result parsers
- Minor updates based on internal review

Closes #114