### PR TITLE
Increase Default Discovery Timeout Treshold

### DIFF
--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -138,6 +138,7 @@ namespace BoostTestAdapter
 
             SetUp(frameworkHandle);
 
+            Logger.Debug("RunSettings: {0}", runContext.RunSettings.SettingsXml);
             BoostTestAdapterSettings settings = BoostTestAdapterSettingsProvider.GetSettings(runContext);
 
             foreach (string source in sources)
@@ -203,7 +204,8 @@ namespace BoostTestAdapter
             Code.Require(frameworkHandle, "frameworkHandle");
 
             SetUp(frameworkHandle);
-
+            
+            Logger.Debug("RunSettings: {0}", runContext.RunSettings.SettingsXml);
             BoostTestAdapterSettings settings = BoostTestAdapterSettingsProvider.GetSettings(runContext);
 
             // Batch tests into grouped runs based on test source and test suite so that we minimize symbol reloading

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -29,7 +29,7 @@ namespace BoostTestAdapter.Settings
         {
             this.TestRunnerSettings = new BoostTestRunnerSettings();
 
-            this.DiscoveryTimeoutMilliseconds = 5000;
+            this.DiscoveryTimeoutMilliseconds = 30000;
 
             this.CommandLineArgs = new BoostTestRunnerCommandLineArgs();
             
@@ -78,7 +78,7 @@ namespace BoostTestAdapter.Settings
             }
         }
 
-        [DefaultValue(5000)]
+        [DefaultValue(30000)]
         public int DiscoveryTimeoutMilliseconds { get; set; }
 
         [DefaultValue(false)]
@@ -120,7 +120,7 @@ namespace BoostTestAdapter.Settings
 
         public ExternalBoostTestRunnerSettings ExternalTestRunner { get; set; }
 
-        [DefaultValue(TestBatch.Strategy.TestSuite)]
+        [DefaultValue(TestBatch.Strategy.TestCase)]
         public TestBatch.Strategy TestBatchStrategy { get; set; }
 
         [DefaultValue(true)]

--- a/BoostTestAdapter/Utility/TemporaryFile.cs
+++ b/BoostTestAdapter/Utility/TemporaryFile.cs
@@ -16,17 +16,25 @@ namespace BoostTestAdapter.Utility
         {
             this.Path = path;
         }
-        
+
         /// <summary>
         /// Tries to delete the temporary file
         /// </summary>
         /// <returns>true if deletion is successful; false otherwise</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private bool Delete()
         {
-            if (File.Exists(this.Path))
+            try
+            { 
+                if (File.Exists(this.Path))
+                {
+                    File.Delete(this.Path);
+                    return true;
+                }
+            }
+            catch (Exception ex)
             {
-                File.Delete(this.Path);
-                return true;
+                Logger.Exception(ex, "Exception caught while trying to delete temporary file [{0}]", this.Path);
             }
 
             return false;

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -45,7 +45,7 @@ namespace BoostTestAdapterNunit
         private void AssertDefaultSettings(BoostTestAdapterSettings settings)
         {
             Assert.That(settings.ExecutionTimeoutMilliseconds, Is.EqualTo(-1));
-            Assert.That(settings.DiscoveryTimeoutMilliseconds, Is.EqualTo(5000));
+            Assert.That(settings.DiscoveryTimeoutMilliseconds, Is.EqualTo(30000));
             Assert.That(settings.FailTestOnMemoryLeak, Is.False);
             Assert.That(settings.ConditionalInclusionsFilteringEnabled, Is.True);
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.TestSuite));
@@ -212,7 +212,7 @@ namespace BoostTestAdapterNunit
             BoostTestAdapterSettings settings = Parse("BoostTestAdapterNunit.Resources.Settings.externalTestRunner.runsettings");
 
             Assert.That(settings.ExecutionTimeoutMilliseconds, Is.EqualTo(-1));
-            Assert.That(settings.DiscoveryTimeoutMilliseconds, Is.EqualTo(5000));
+            Assert.That(settings.DiscoveryTimeoutMilliseconds, Is.EqualTo(30000));
             Assert.That(settings.FailTestOnMemoryLeak, Is.False);
             Assert.That(settings.ConditionalInclusionsFilteringEnabled, Is.True);
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.TestSuite));

--- a/BoostTestAdapterNunit/Resources/Settings/externalTestRunner.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/externalTestRunner.runsettings
@@ -11,7 +11,6 @@
             </DiscoveryFileMap>
             <ExecutionCommandLine>C:\ExternalTestRunner.exe --test "{source}"</ExecutionCommandLine>
         </ExternalTestRunner>
-        <TestBatchStrategy>TestCase</TestBatchStrategy>
         <Filters />
     </BoostTest>		
 </RunSettings>

--- a/BoostTestAdapterNunit/Resources/Settings/sample.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/sample.runsettings
@@ -15,7 +15,6 @@
             <DiscoveryCommandLine>C:\ExternalTestRunner.exe --test "{source}" --list-debug "{out}"</DiscoveryCommandLine>
             <ExecutionCommandLine>C:\ExternalTestRunner.exe --test "{source}"</ExecutionCommandLine>
         </ExternalTestRunner>
-        <TestBatchStrategy>TestCase</TestBatchStrategy>
         <Filters />
     </BoostTest>
 


### PR DESCRIPTION
- Increase the default timeout threshold from 5s to 30s since it was not adequate for general use.
- Silence exception in case a temporary file cannot be deleted successfully.