### PR TITLE
Fix Line Numbers When Multi-line String Literals are Used

### DIFF
--- a/BoostTestAdapter/SourceFilter/QuotedStringsFilter.cs
+++ b/BoostTestAdapter/SourceFilter/QuotedStringsFilter.cs
@@ -10,7 +10,7 @@ using VisualStudioAdapter;
 namespace BoostTestAdapter.SourceFilter
 {
     /// <summary>
-    /// Filters any quoted strings from the sourcecode. This filtering process is required so as to simplyfy the subsequent filtering operations
+    /// Filters any quoted strings from the source code. This filtering process is required so as to simplify the subsequent filtering operations
     /// </summary>
     public class QuotedStringsFilter : ISourceFilter
     {
@@ -46,6 +46,7 @@ namespace BoostTestAdapter.SourceFilter
         //            Match any character that is NOT a “"” «[^"]»
         //      Match the character “"” literally «"»
 
+        // Reference: http://stackoverflow.com/questions/3219014/what-is-a-cross-platform-regex-for-removal-of-line-breaks
         private static readonly Regex lineBreakRegex = new Regex(@"\r\n?|\n", RegexOptions.Singleline | RegexOptions.Multiline);
         
         //Options: Case insensitive; Exact spacing; Dot matches line breaks; ^$ don't match at line breaks; Numbered capture
@@ -82,21 +83,16 @@ namespace BoostTestAdapter.SourceFilter
         /// <returns>the replacement string</returns>
         private string ComputeReplacement(Match m)
         {
-            if (m.Groups.Count > 1 && m.Groups[1].Success)
+            StringBuilder replacementString = new StringBuilder();
+
+            Match matchLineBreak = lineBreakRegex.Match(m.Value);
+            while (matchLineBreak.Success)
             {
-                StringBuilder replacementString = new StringBuilder();
-
-                Match matchLineBreak = lineBreakRegex.Match(m.Groups[1].Value);
-                while (matchLineBreak.Success)
-                {
-                    replacementString.Append(matchLineBreak.Value); //line break types are preserved
-                    matchLineBreak = matchLineBreak.NextMatch();
-                }
-
-                return replacementString.ToString();
+                replacementString.Append(matchLineBreak.Value); //line break types are preserved
+                matchLineBreak = matchLineBreak.NextMatch();
             }
 
-            return string.Empty;
+            return replacementString.ToString();
         }
     }
 }

--- a/BoostTestAdapterNunit/BoostTestSourceDiscovererTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSourceDiscovererTest.cs
@@ -271,6 +271,9 @@ namespace BoostTestAdapterNunit
 
             VSTestCase testConditional = AssertTestDetails(tests, QualifiedNameBuilder.FromString("BoostUnitTestConditional"), source);
             AssertSourceDetails(testConditional, codeFilePath, 54);
+
+            VSTestCase testMultiline = AssertTestDetails(tests, QualifiedNameBuilder.FromString("some_test"), source);
+            AssertSourceDetails(testMultiline, codeFilePath, 72);
         }
 
         #endregion Helper Methods
@@ -382,7 +385,7 @@ namespace BoostTestAdapterNunit
             using (DummySolution solution = new DummySolution(Source, new string[] { BoostUnitTestSampleRequiringUseOfFilters }))
             {
                 IEnumerable<VSTestCase> vsTests = Discover(solution);
-                Assert.That(vsTests.Count(), Is.EqualTo(7));
+                Assert.That(vsTests.Count(), Is.EqualTo(8));
                 AssertBoostUnitTestSampleRequiringUseOfFilters(vsTests, solution);
             }
         }
@@ -404,7 +407,7 @@ namespace BoostTestAdapterNunit
 
                 IEnumerable<VSTestCase> vsTests = Discover(solution, context);
 
-                Assert.That(vsTests.Count(), Is.EqualTo(8));
+                Assert.That(vsTests.Count(), Is.EqualTo(9));
                 AssertBoostUnitTestSampleRequiringUseOfFilters(vsTests, solution);
 
                 VSTestCase testConditional = AssertTestDetails(vsTests, QualifiedNameBuilder.FromString("BoostUnitTestShouldNotAppear3"), Source);

--- a/BoostTestAdapterNunit/Resources/CppSources/BoostUnitTestSampleRequiringUseOfFilters.cpp
+++ b/BoostTestAdapterNunit/Resources/CppSources/BoostUnitTestSampleRequiringUseOfFilters.cpp
@@ -64,3 +64,12 @@ BOOST_AUTO_TEST_CASE( BoostUnitTestShouldNotAppear4 )
 BOOST_WARN( sizeof(int) == sizeof(short) );
 }
 */
+
+const char * const s = "Hello, \
+world!"
+
+/// test line number should not be offset
+BOOST_AUTO_TEST_CASE(some_test)
+{
+    BOOST_CHECK(true)
+}

--- a/BoostTestAdapterNunit/Resources/SourceFiltering/QuotedStringsFilterTest_FilteredSourceCode.cpp
+++ b/BoostTestAdapterNunit/Resources/SourceFiltering/QuotedStringsFilterTest_FilteredSourceCode.cpp
@@ -13,3 +13,5 @@ const wchar_t* newline =
 ;
 char str[] =  ;
 const wchar_t* raw_wide =  + ;
+const char* const multiline = 
+;

--- a/BoostTestAdapterNunit/Resources/SourceFiltering/QuotedStringsFilterTest_UnFilteredSourceCode.cpp
+++ b/BoostTestAdapterNunit/Resources/SourceFiltering/QuotedStringsFilterTest_UnFilteredSourceCode.cpp
@@ -13,3 +13,5 @@ const wchar_t* newline = LR"(hello
 goodbye)";
 char str[] = "12" "34";
 const wchar_t* raw_wide = LR"(An unescaped " character)" + R"(An unescaped " character)";
+const char* const multiline = "Hello \
+                                World";

--- a/BoostTestAdapterNunit/SourceFiltersTest.cs
+++ b/BoostTestAdapterNunit/SourceFiltersTest.cs
@@ -24,6 +24,7 @@ namespace BoostTestAdapterNunit
         [TestCase("BOOST_MESSAGE(\"This is a test\\\"\");", Result = "BOOST_MESSAGE();")]
         [TestCase("BOOST_MESSAGE(\"This is a just a\\\" test\");", Result = "BOOST_MESSAGE();")]
         [TestCase("#include \"stdafx.h\"", Result = "#include ")]
+        [TestCase("const char* const cikku = \"Hello /\r\nWorld\"", Result = "const char* const cikku = \r\n")]
         public string FilterQuotedString(string input)
         {
             ISourceFilter filter = new QuotedStringsFilter();


### PR DESCRIPTION
Fixes the issue mentioned in #100 when utilising source code discovery.

Closes #100