### PR TITLE
If a Test Fails in a BOOST_DATA_TEST_CASE, Mark as Failed

### DIFF
--- a/BoostTestAdapter/Boost/Results/BoostXmlLog.cs
+++ b/BoostTestAdapter/Boost/Results/BoostXmlLog.cs
@@ -157,7 +157,7 @@ namespace BoostTestAdapter.Boost.Results
             if (testingTime != null)
             {
                 // Boost test testing time is listed in microseconds
-                result.Duration = ulong.Parse(testingTime.InnerText, CultureInfo.InvariantCulture);
+                result.Duration += ulong.Parse(testingTime.InnerText, CultureInfo.InvariantCulture);
             }
 
             ParseTestCaseLogEntries(node.ChildNodes, result);

--- a/BoostTestAdapter/Boost/Results/TestResult.cs
+++ b/BoostTestAdapter/Boost/Results/TestResult.cs
@@ -13,12 +13,12 @@ namespace BoostTestAdapter.Boost.Results
     /// <summary>
     /// Test result enumeration.
     /// </summary>
-    public enum TestResultType
+    public enum TestResultType : int
     {
-        Passed,
-        Skipped,
-        Aborted,
-        Failed
+        Passed = 0,
+        Skipped = 1,
+        Aborted = 2,
+        Failed = 3
     }
 
     /// <summary>
@@ -42,6 +42,7 @@ namespace BoostTestAdapter.Boost.Results
         {
             this.Collection = collection;
             this.LogEntries = new List<LogEntry>();
+            this.Duration = 0;
         }
 
         /// <summary>

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -94,7 +94,10 @@ namespace BoostTestAdapter.Boost.Runner
                     Logger.Exception(ex, "Could not create a DBGHELP instance for '{0}' to determine whether symbols are available.", this.Source);
                 }
                 
-                Logger.Warn("Could not locate debug symbols for '{0}'. To make use of '--list_content' discovery, ensure that debug symbols are available or make use of '<ForceListContent>' via a .runsettings file.", this.TestRunnerExecutable);
+                if (!supported)
+                {
+                    Logger.Warn("Could not locate debug symbols for '{0}'. To make use of '--list_content' discovery, ensure that debug symbols are available or make use of '<ForceListContent>' via a .runsettings file.", this.TestRunnerExecutable);
+                }
 
                 return supported;
             }

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -204,6 +204,10 @@
     <EmbeddedResource Include="Resources\ReportsLogs\TestContext\ExampleBoostUnittest.exe.test.log.xml" />
     <EmbeddedResource Include="Resources\ReportsLogs\TestContext\ExampleBoostUnittest.exe.test.report.xml" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\ReportsLogs\DataTestCase\sample.test.report.xml" />
+    <EmbeddedResource Include="Resources\ReportsLogs\DataTestCase\sample.test.log.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/BoostTestAdapterNunit/BoostTestResultTest.cs
+++ b/BoostTestAdapterNunit/BoostTestResultTest.cs
@@ -951,5 +951,35 @@ namespace BoostTestAdapterNunit
                 });
             }
         }
+
+        /// <summary>
+        /// Assert that multiple test reports for the same test are aggregated under the same result
+        /// </summary>
+        [Test]
+        public void DataTestCaseResultAggregation()
+        {
+            using (Stream report = TestHelper.LoadEmbeddedResource("BoostTestAdapterNunit.Resources.ReportsLogs.DataTestCase.sample.test.report.xml"))
+            using (Stream log = TestHelper.LoadEmbeddedResource("BoostTestAdapterNunit.Resources.ReportsLogs.DataTestCase.sample.test.log.xml"))
+            using (Stream stdout = TestHelper.LoadEmbeddedResource("BoostTestAdapterNunit.Resources.ReportsLogs.Empty.sample.test.stdout.log"))
+            using (Stream stderr = TestHelper.LoadEmbeddedResource("BoostTestAdapterNunit.Resources.ReportsLogs.Empty.sample.test.stderr.log"))
+            {
+                Parse(report, log, stdout, stderr);
+
+                BoostTestResult masterSuiteResult = this.TestResultCollection[string.Empty];
+                Assert.That(masterSuiteResult, Is.Not.Null);
+
+
+                // NOTE The values here do not match the Xml report file since the results are aggregated as one.
+                //      All tests are considered as failed since they share the same result.
+                AssertReportDetails(masterSuiteResult, null, "MultipleTests", TestResultType.Failed, 4, 1, 0, 0, 1, 0, 0);
+                
+                BoostTestResult testCaseResult = this.TestResultCollection["test_case_arity1_implicit"];
+                Assert.That(testCaseResult, Is.Not.Null);
+
+                AssertReportDetails(testCaseResult, masterSuiteResult, "test_case_arity1_implicit", TestResultType.Failed, 4, 1, 0);
+
+                Assert.That(testCaseResult.Duration, Is.EqualTo(4000));
+            }
+        }
     }
 }

--- a/BoostTestAdapterNunit/Resources/ReportsLogs/DataTestCase/sample.test.log.xml
+++ b/BoostTestAdapterNunit/Resources/ReportsLogs/DataTestCase/sample.test.log.xml
@@ -1,0 +1,27 @@
+<TestLog>
+	<TestSuite name="MultipleTests">
+		<TestCase name="test_case_arity1_implicit">
+			<TestingTime>1000</TestingTime>
+		</TestCase>
+		<TestCase name="test_case_arity1_implicit">
+			<TestingTime>0</TestingTime>
+		</TestCase>
+		<TestCase name="test_case_arity1_implicit">
+			<TestingTime>1000</TestingTime>
+		</TestCase>
+		<TestCase name="test_case_arity1_implicit">
+			<Error file="c:/users/brian/documents/projects/boost unit test adapter/sample/boostunittest/misc/boosttestdata.cpp" line="9">
+				<![CDATA[check sample != 3 has failed [3 == 3]]]>
+				<Context>
+					<Frame>
+						<![CDATA[sample = 3; ]]>
+					</Frame>
+				</Context>
+			</Error>
+			<TestingTime>1000</TestingTime>
+		</TestCase>
+		<TestCase name="test_case_arity1_implicit">
+			<TestingTime>1000</TestingTime>
+		</TestCase>
+	</TestSuite>
+</TestLog>

--- a/BoostTestAdapterNunit/Resources/ReportsLogs/DataTestCase/sample.test.report.xml
+++ b/BoostTestAdapterNunit/Resources/ReportsLogs/DataTestCase/sample.test.report.xml
@@ -1,0 +1,9 @@
+<TestResult>
+	<TestSuite name="MultipleTests" result="failed" assertions_passed="4" assertions_failed="1" warnings_failed="0" expected_failures="0" test_cases_passed="4" test_cases_passed_with_warnings="0" test_cases_failed="1" test_cases_skipped="0" test_cases_aborted="0">
+		<TestCase name="test_case_arity1_implicit" result="passed" assertions_passed="1" assertions_failed="0" warnings_failed="0" expected_failures="0"/>
+		<TestCase name="test_case_arity1_implicit" result="passed" assertions_passed="1" assertions_failed="0" warnings_failed="0" expected_failures="0"/>
+		<TestCase name="test_case_arity1_implicit" result="passed" assertions_passed="1" assertions_failed="0" warnings_failed="0" expected_failures="0"/>
+		<TestCase name="test_case_arity1_implicit" result="failed" assertions_passed="0" assertions_failed="1" warnings_failed="0" expected_failures="0"/>
+		<TestCase name="test_case_arity1_implicit" result="passed" assertions_passed="1" assertions_failed="0" warnings_failed="0" expected_failures="0"/>
+	</TestSuite>
+</TestResult>


### PR DESCRIPTION
If at least a single test case fails within a BOOST_DATA_TEST_CASE, mark the test as failed within the test explorer. This is achieved by aggregating results which point to the same test case, common in BOOST_DATA_TEST_CASE scenarios, and avoid overwriting available results.

In addition:
- Fix warning display if `--list_content` is not supported.