### PR TITLE
Enforce backward slashes for working dir

### DIFF
--- a/BoostTestAdapter/Utility/BoostTestRunnerCommandLineArgsEx.cs
+++ b/BoostTestAdapter/Utility/BoostTestRunnerCommandLineArgsEx.cs
@@ -73,6 +73,8 @@ namespace BoostTestAdapter.Utility
                     args.SetEnvironment(vsConfiguration.Environment);
                 }
             }
+            // Enforce windows style backward slashes
+            args.WorkingDirectory = args.WorkingDirectory.Replace('/', '\\');
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes the bug where the debugger is not launching if the working directory in the project configuration contains forward slashes. The regular debugger accepts those, but the undocumented `LaunchProcessWithDebuggerAttached` does not accept them.

Closes #132 