### PR TITLE
Added Enabled/Disabled Trait for Test Grouping

### DIFF
--- a/BoostTestAdapter/Boost/Test/TestFrameworkBuilder.cs
+++ b/BoostTestAdapter/Boost/Test/TestFrameworkBuilder.cs
@@ -33,7 +33,20 @@ namespace BoostTestAdapter.Boost.Test
         /// <param name="source">Boost Test EXE/Dll file path</param>
         /// <param name="name">Name of Master Test Suite</param>
         /// <param name="id">Id of Master Test Suite</param>
-        public TestFrameworkBuilder(string source, string name, int? id)
+        public TestFrameworkBuilder(string source, string name, int? id) :
+            this(source, name, id, true)
+        {
+        }
+        
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="source">Boost Test EXE/Dll file path</param>
+        /// <param name="name">Name of Master Test Suite</param>
+        /// <param name="id">Id of Master Test Suite</param>
+        /// <param name="enabled">Master Test Suite enabled or disabled (due to Boost 1.59)</param>
+        public TestFrameworkBuilder(string source, string name, int? id, bool enabled)
         {
             this.Source = source;
 
@@ -46,6 +59,8 @@ namespace BoostTestAdapter.Boost.Test
             this.MasterTestSuite.Id = id;
 
             this.Parent = this.MasterTestSuite;
+
+            this.MasterTestSuite.DefaultEnabled = enabled;
         }
 
         #endregion Constructors
@@ -102,11 +117,18 @@ namespace BoostTestAdapter.Boost.Test
         /// <returns>this</returns>
         public TestFrameworkBuilder TestSuite(string name, int? id, SourceFileInfo source)
         {
+            return this.TestSuite(name, id, source, true);
+        }
+
+        public TestFrameworkBuilder TestSuite(string name, int? id, SourceFileInfo source, bool enabled)
+        {
             TestSuite testSuite = new TestSuite(name, this.Parent);
             testSuite.Id = id;
             testSuite.Source = source;
 
             this.Parent = testSuite;
+
+            testSuite.DefaultEnabled = enabled;
 
             return this;
         }
@@ -154,14 +176,30 @@ namespace BoostTestAdapter.Boost.Test
         /// <returns>this</returns>
         public TestFrameworkBuilder TestCase(string name, int? id, SourceFileInfo source, IEnumerable<string> labels)
         {
+            return this.TestCase(name, id, source, labels, true);
+        }
+
+        /// <summary>
+        /// Builds a new TestCase.
+        /// </summary>
+        /// <param name="name">Test Case Name</param>
+        /// <param name="id">Test Case Id</param>
+        /// <param name="source">Test Case source file debug information</param>
+        /// <param name="labels">Test Case labels</param>
+        /// <param name="enabled">Test Case enabled or disabled</param>
+        /// <returns>this</returns>
+        public TestFrameworkBuilder TestCase(string name, int? id, SourceFileInfo source, IEnumerable<string> labels, bool enabled)
+        {
             TestCase testCase = new TestCase(name, this.Parent);
 
             testCase.Id = id;
             testCase.Source = source;
-            testCase.Labels = labels;
+            testCase.Labels = ((labels == null)? Enumerable.Empty<string>() : labels);
+            testCase.DefaultEnabled = enabled;
 
             return this;
         }
+
 
         /// <summary>
         /// Ends the current TestSuite context and moves up one level in the hierarchy.

--- a/BoostTestAdapter/Boost/Test/TestFrameworkDOTDeserialiser.cs
+++ b/BoostTestAdapter/Boost/Test/TestFrameworkDOTDeserialiser.cs
@@ -206,7 +206,7 @@ namespace BoostTestAdapter.Boost.Test
                 };
 
                 this.Context.TestUnits.Push(info);
-
+           
                 return base.VisitNode_stmt(context);
             }
 
@@ -348,6 +348,8 @@ namespace BoostTestAdapter.Boost.Test
                 unit.Source = info.SourceInfo;
                 unit.Labels = info.Labels;
 
+                unit.DefaultEnabled = info.DefaultEnabled;   
+
                 // Default Enabled
                 // Timeout
                 // Expected Failures
@@ -386,9 +388,11 @@ namespace BoostTestAdapter.Boost.Test
                     this.Timeout = 0;
                     this.ExpectedFailures = 0;
                     this.Labels = Enumerable.Empty<string>();
-
+                    
                     this.Parents = new List<string>();
                     this.Dependencies = new List<string>();
+
+                    this.DefaultEnabled = true;
                 }
 
                 /// <summary>
@@ -445,7 +449,7 @@ namespace BoostTestAdapter.Boost.Test
                 public TestUnitInfo Parse(string value)
                 {
                     TestUnitInfo info = new TestUnitInfo(this.id);
-
+                    info.DefaultEnabled = this.DefaultEnabled;
                     string[] properties = value.Split('|');
 
                     if (properties.Length > 0)

--- a/BoostTestAdapter/Boost/Test/TestUnit.cs
+++ b/BoostTestAdapter/Boost/Test/TestUnit.cs
@@ -30,7 +30,9 @@ namespace BoostTestAdapter.Boost.Test
             this.Name = name;
             this.Parent = parent;
             this.Labels = Enumerable.Empty<string>();
-            
+
+            this.DefaultEnabled = true;
+
             if (parent != null)
             {
                 parent.AddChild(this);
@@ -77,6 +79,8 @@ namespace BoostTestAdapter.Boost.Test
         /// </summary>
         public IEnumerable<string> Labels { get; set; }
 
+
+
         /// <summary>
         /// Cached version of the fully qualified name builder
         /// </summary>
@@ -109,6 +113,12 @@ namespace BoostTestAdapter.Boost.Test
                 return FullyQualifiedNameBuilder.ToString();
             }
         }
+
+        /// <summary>
+        ///  Identifies whether the test is explicitly disabled by setting this value to false
+        /// </summary>
+
+        public bool DefaultEnabled { get; set; }
 
         #endregion Properties
 

--- a/BoostTestAdapter/Discoverers/TestCaseUtils.cs
+++ b/BoostTestAdapter/Discoverers/TestCaseUtils.cs
@@ -64,7 +64,7 @@ namespace BoostTestAdapter.Discoverers
             }
             else
             {
-                testCase.Traits.Add(VSTestModel.DisabledTestSuiteTrait, traitName);
+                testCase.Traits.Add(VSTestModel.StatusTrait, traitName);
             };
         }
 

--- a/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
+++ b/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
@@ -85,6 +85,7 @@ namespace BoostTestAdapter.Discoverers
         /// </summary>
         /// <param name="testCase">The Boost.Test.TestCase to convert.</param>
         /// <returns>An equivalent Visual Studio TestCase structure to the one provided.</returns>
+       
         private VSTestCase GenerateTestCase(TestCase testCase)
         {
             VSTestCase test = new VSTestCase(
@@ -109,6 +110,9 @@ namespace BoostTestAdapter.Discoverers
 
             // Register the test suite as a trait
             test.Traits.Add(new Trait(VSTestModel.TestSuiteTrait, GetParentFullyQualifiedName(testCase)));
+            
+            // Register enabled and disabled as traits
+            test.Traits.Add(new Trait(VSTestModel.StatusTrait, (testCase.DefaultEnabled ? VSTestModel.TestEnabled : VSTestModel.TestDisabled)));
 
             TestUnit unit = testCase;
             while (unit != null)
@@ -116,9 +120,9 @@ namespace BoostTestAdapter.Discoverers
                 foreach (string label in unit.Labels)
                 {
                     // Register each and every label as an individual trait
-                    test.Traits.Add(new Trait(VSTestModel.LabelTrait, ('@' + label)));
-                }
-                
+                    test.Traits.Add(new Trait(VSTestModel.LabelTrait, ("@" + label)));
+                }             
+
                 // Test cases inherit the labels of parent test units
                 // Reference: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/tests_organization/tests_grouping.html
                 unit = unit.Parent;

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -54,6 +54,8 @@ namespace BoostTestAdapter.Settings
             this.EnableStdErrRedirection = true;
 
             this.Filters = TestSourceFilter.Empty;
+
+            this.RunDisabledTests = false;
         }
 
         #region Properties
@@ -137,7 +139,10 @@ namespace BoostTestAdapter.Settings
 
         [XmlIgnore]
         public BoostTestRunnerCommandLineArgs CommandLineArgs { get; private set; }
-        
+
+        [DefaultValue(false)]
+        public bool RunDisabledTests { get; set; }
+
         #endregion Properties
 
         #region TestRunSettings

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -49,11 +49,11 @@ namespace BoostTestAdapter.Utility.VisualStudio
         /// <summary>
         /// TestSuite trait name
         /// </summary>
-        public static string DisabledTestSuiteTrait
+        public static string StatusTrait
         {
             get
             {
-                return "Disabled";
+                return "Status";
             }
         }
 
@@ -68,7 +68,27 @@ namespace BoostTestAdapter.Utility.VisualStudio
             return path_in.Replace('/', '\\');
         }
 
+        /// <summary>
+        /// Constant Used to indicate that the test is Enabled
+        /// </summary>
+        public static string TestEnabled
+        {
+            get
+            {
+                return "Enabled";
+            }
+        }
 
+        /// <summary>
+        /// Constant Used to indicate that the test is Disabled
+        /// </summary>
+        public static string TestDisabled
+        {
+            get
+            {
+                return "Disabled";
+            }
+        }
 
         /// <summary>
         /// Converts a Boost.Test.Result.TestResult model into an equivalent

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -119,6 +119,7 @@
     <EmbeddedResource Include="Resources\ListContentDOT\sample.list.content.gv" />
     <EmbeddedResource Include="Resources\ListContentDOT\sample.8.list.content.gv" />
     <EmbeddedResource Include="Resources\ReportsLogs\MemoryLeakTest\sample.test.stderr.log" />
+    <EmbeddedResource Include="Resources\ListContentDOT\test_list_content.gv" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\ReportsLogs\AbortedTest\sample.test.log.xml" />

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -56,6 +56,7 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.EnableStdOutRedirection, Is.True);
             Assert.That(settings.EnableStdErrRedirection, Is.True);
             Assert.That(settings.Filters, Is.EqualTo(TestSourceFilter.Empty));
+            Assert.That(settings.RunDisabledTests, Is.False);
         }
 
 
@@ -139,6 +140,8 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.CatchSystemErrors, Is.False);
             Assert.That(settings.DetectFloatingPointExceptions, Is.True);
             Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestSuite));
+
+            Assert.That(settings.RunDisabledTests, Is.True);
 
             Assert.That(settings.Filters, Is.Not.Null);
             Assert.That(settings.Filters.Include, Is.Not.Empty);

--- a/BoostTestAdapterNunit/DOTDeserialisationTest.cs
+++ b/BoostTestAdapterNunit/DOTDeserialisationTest.cs
@@ -44,7 +44,7 @@ namespace BoostTestAdapterNunit
                 TestFrameworkDOTDeserialiser parser = new TestFrameworkDOTDeserialiser(Source);
                 TestFramework framework = parser.Deserialise(stream);
 
-                FrameworkEqualityVisitor.IsEqualTo(framework, expected);
+                FrameworkEqualityVisitor.IsEqualTo(framework, expected, false);
             }
         }
 
@@ -59,44 +59,44 @@ namespace BoostTestAdapterNunit
         [Test]
         public void DeserialiseDOT()
         {
-            TestFramework expected = new TestFrameworkBuilder(Source, "sample", 1).
-                TestSuite("suite_1", 2, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 6)).
-                    TestSuite("suite_2", 3, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 8)).
-                        TestCase("test_3", 65536, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 14)).
-                        TestCase("test_4", 65537, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 44)).
-                        TestCase("test_5", 65538, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 62)).
+            TestFramework expected = new TestFrameworkBuilder(Source, "sample", 1, false).
+                TestSuite("suite_1", 2, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 6), false).
+                    TestSuite("suite_2", 3, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 8), false).
+                        TestCase("test_3", 65536, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 14), null, false).
+                        TestCase("test_4", 65537, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 44), null, false).
+                        TestCase("test_5", 65538, new SourceFileInfo(@"d:\sample.boostunittest\file_1.cpp", 62), null, false).
                     EndSuite().
-                    TestSuite("suite_6", 4, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 19)).
-                        TestCase("test_7", 65539, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 24)).
-                        TestCase("test_8", 65540, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 40)).
-                        TestCase("test_9", 65541, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 90)).
-                        TestCase("test_10", 65542, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 405)).
-                        TestCase("test_11", 65543, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 121)).
-                        TestCase("test_12", 65544, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 134)).
-                        TestCase("test_13", 65545, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 310)).
+                    TestSuite("suite_6", 4, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 19), false).
+                        TestCase("test_7", 65539, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 24), null, false).
+                        TestCase("test_8", 65540, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 40), null, false).
+                        TestCase("test_9", 65541, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 90), null, false).
+                        TestCase("test_10", 65542, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 105), null, false).
+                        TestCase("test_11", 65543, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 121), null, false).
+                        TestCase("test_12", 65544, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 134), null, false).
+                        TestCase("test_13", 65545, new SourceFileInfo(@"d:\sample.boostunittest\file_2.cpp", 310), null, false).
                     EndSuite().
-                    TestSuite("suite_14", 5, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 19)).
-                        TestCase("test_15", 65546, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 27)).
-                        TestCase("test_16", 65547, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 49)).
-                        TestCase("test_17", 65548, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 54)).
-                        TestCase("test_18", 65549, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 88)).
+                    TestSuite("suite_14", 5, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 20), false).
+                        TestCase("test_15", 65546, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 27), null, false).
+                        TestCase("test_16", 65547, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 49), null, false).
+                        TestCase("test_17", 65548, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 59), null, false).
+                        TestCase("test_18", 65549, new SourceFileInfo(@"d:\sample.boostunittest\file_3.cpp", 88), null, false).
                     EndSuite().
-                    TestSuite("suite_19", 6, new SourceFileInfo(@"d:\sample.boostunittest\file_4.cpp", 7)).
-                        TestCase("test_20", 65550, new SourceFileInfo(@"d:\sample.boostunittest\file_4.cpp", 12)).
+                    TestSuite("suite_19", 6, new SourceFileInfo(@"d:\sample.boostunittest\file_4.cpp", 7), false).
+                        TestCase("test_20", 65550, new SourceFileInfo(@"d:\sample.boostunittest\file_4.cpp", 12), null, false).
                     EndSuite().
-                    TestSuite("suite_21", 7, new SourceFileInfo(@"d:\sample.boostunittest\file_5.cpp", 8)).
-                        TestCase("test_22", 65551, new SourceFileInfo(@"d:\sample.boostunittest\file_5.cpp", 14)).
+                    TestSuite("suite_21", 7, new SourceFileInfo(@"d:\sample.boostunittest\file_5.cpp", 8), false).
+                        TestCase("test_22", 65551, new SourceFileInfo(@"d:\sample.boostunittest\file_5.cpp", 14), null, false).
                     EndSuite().
-                    TestSuite("suite_23", 8, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 13)).
-                        TestCase("test_24", 65552, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 18)).
-                        TestCase("test_25", 65553, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 28)).
-                        TestCase("test_26", 65554, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 38)).
-                        TestCase("test_27", 65555, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 48)).
-                        TestCase("test_28", 65556, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 59)).
-                        TestCase("test_29", 65557, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 70)).
+                    TestSuite("suite_23", 8, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 13), false).
+                        TestCase("test_24", 65552, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 18), null, false).
+                        TestCase("test_25", 65553, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 28), null, false).
+                        TestCase("test_26", 65554, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 38), null, false).
+                        TestCase("test_27", 65555, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 48), null, false).
+                        TestCase("test_28", 65556, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 59), null, false).
+                        TestCase("test_29", 65557, new SourceFileInfo(@"d:\sample.boostunittest\file_6.cpp", 70), null, false).
                     EndSuite().
-                    TestSuite("suite_30", 9, new SourceFileInfo(@"d:\sample.boostunittest\file_7.cpp", 8)).
-                        TestCase("test_31", 65558, new SourceFileInfo(@"d:\sample.boostunittest\file_7.cpp", 14), new[] { "hello", "world", "labels" }).
+                    TestSuite("suite_30", 9, new SourceFileInfo(@"d:\sample.boostunittest\file_7.cpp", 8), false).
+                        TestCase("test_31", 65558, new SourceFileInfo(@"d:\sample.boostunittest\file_7.cpp", 14), new[] { "hello", "world", "labels" }, false).
                     EndSuite().
                 EndSuite().
             Build();
@@ -119,15 +119,42 @@ namespace BoostTestAdapterNunit
         [Test]
         public void TestSuiteWithChildTestsAndSuites()
         {
-            TestFramework expected = new TestFrameworkBuilder(Source, "MyTest", 1).
-                TestCase("Test", 65536, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 30)).
-                TestSuite("Suite", 2, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 35)).
-                    TestCase("Test", 65537, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 37)).
+            TestFramework expected = new TestFrameworkBuilder(Source, "MyTest", 1, false).
+                TestCase("Test", 65536, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 30),null, false).
+                TestSuite("Suite", 2, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 35), false).
+                    TestCase("Test", 65537, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 37),null, false).
                 EndSuite().
-                TestCase("TestB", 65538, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 44)).
+                TestCase("TestB", 65538, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 44), null, false).
             Build();
 
             Compare("BoostTestAdapterNunit.Resources.ListContentDOT.sample.3.list.content.gv", expected);
+        }
+
+        
+        /// <summary>
+        /// Deserialisation of Boost Test DOT content consisting of test cases which are
+        /// explicitly enabled or disabled using boost decorators
+        /// 
+        /// Test aims:
+        ///     - Ensure that the decorators are correctly read and grouping is done correctly 
+        /// </summary>
+        [Test]
+        public void TestsWithDecorators()
+        {
+            TestFramework expected = new TestFrameworkBuilder(Source, "Sample", 1).
+                TestSuite("Suite1", 2, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 11)).
+                    TestCase("MyBoost_Test1", 65536, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 12)).
+                    TestCase("MyBoost_Test2", 65537, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 16), null, false).
+                    TestCase("MyBoost_Test3", 65538, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 20)).
+                    TestCase("MyBoost_Test4", 65539, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 24), null, false).
+                EndSuite().
+                TestCase("MyBoost_Test5", 65540, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 30)).
+                TestCase("MyBoost_Test6", 65541, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 34), null, false).
+                TestCase("MyBoost_Test7", 65542, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 38)).
+                TestCase("MyBoost_Test8", 65543, new SourceFileInfo(@"c:\boostunittest\boostunittestsample.cpp", 42), null, false).
+            Build();
+
+            Compare("BoostTestAdapterNunit.Resources.ListContentDOT.test_list_content.gv", expected);
         }
     }
 }

--- a/BoostTestAdapterNunit/Resources/ListContentDOT/test_list_content.gv
+++ b/BoostTestAdapterNunit/Resources/ListContentDOT/test_list_content.gv
@@ -1,0 +1,25 @@
+digraph G {rankdir=LR;
+tu1[shape=ellipse,peripheries=2,fontname=Helvetica,color=green,label="Sample"];
+{
+tu2[shape=Mrecord,fontname=Helvetica,color=green,label="Suite1|c:\boostunittest\boostunittestsample.cpp(11)"];
+tu1 -> tu2;
+{
+tu65536[shape=Mrecord,fontname=Helvetica,color=green,label="MyBoost_Test1|c:\boostunittest\boostunittestsample.cpp(12)"];
+tu2 -> tu65536;
+tu65537[shape=Mrecord,fontname=Helvetica,color=yellow,label="MyBoost_Test2|c:\boostunittest\boostunittestsample.cpp(16)"];
+tu2 -> tu65537;
+tu65538[shape=Mrecord,fontname=Helvetica,color=green,label="MyBoost_Test3|c:\boostunittest\boostunittestsample.cpp(20)"];
+tu2 -> tu65538;
+tu65539[shape=Mrecord,fontname=Helvetica,color=yellow,label="MyBoost_Test4|c:\boostunittest\boostunittestsample.cpp(24)"];
+tu2 -> tu65539;
+}
+tu65540[shape=Mrecord,fontname=Helvetica,color=green,label="MyBoost_Test5|c:\boostunittest\boostunittestsample.cpp(30)"];
+tu1 -> tu65540;
+tu65541[shape=Mrecord,fontname=Helvetica,color=yellow,label="MyBoost_Test6|c:\boostunittest\boostunittestsample.cpp(34)"];
+tu1 -> tu65541;
+tu65542[shape=Mrecord,fontname=Helvetica,color=green,label="MyBoost_Test7|c:\boostunittest\boostunittestsample.cpp(38)"];
+tu1 -> tu65542;
+tu65543[shape=Mrecord,fontname=Helvetica,color=yellow,label="MyBoost_Test8|c:\boostunittest\boostunittestsample.cpp(42)"];
+tu1 -> tu65543;
+}
+}

--- a/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
+++ b/BoostTestAdapterNunit/Resources/Settings/sample.2.runsettings
@@ -48,6 +48,8 @@
         <!-- Test case-sensitivity -->
         <DetectFloatingPointExceptions>1</DetectFloatingPointExceptions>
 
+		
+		<RunDisabledTests>true</RunDisabledTests>
 
         <Filters>
             <Exclude>


### PR DESCRIPTION
New traits have been added to better distinguish enabled/disabled tests.

In addition, semantics for 'Run All...' have been modified such that by default (i.e. unless configured otherwise) only enabled tests are executed. This was done to mimic the default behaviour of Boost's test execution mechanism. Note that selecting individual tests (or by using playlists), disabled tests are still executed, once again, similar to how Boost's test execution works.

Closes #110.