### PR TITLE
Fix Redirection Operators when Custom Arguments are Specified

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -359,7 +359,7 @@ namespace BoostTestAdapter.Boost.Runner
                 AddArgument(HelpArg, args);
 
                 // return immediately since Boost UTF should ignore the rest of the arguments
-                return AppendRedirection(args).ToString();
+                return AppendRedirection(args).ToString().TrimEnd();
             }
 
             // --list_content
@@ -368,7 +368,7 @@ namespace BoostTestAdapter.Boost.Runner
                 AddArgument(ListContentArg, ListContentFormatToString(this.ListContent.Value), args);
 
                 // return immediately since Boost UTF should ignore the rest of the arguments
-                return AppendRedirection(args).ToString();
+                return AppendRedirection(args).ToString().TrimEnd();
             }
 
             // --run_test=a,b,c
@@ -498,7 +498,6 @@ namespace BoostTestAdapter.Boost.Runner
 
             return args;
         }
-
 
         /// <summary>
         /// Returns a rooted path for the provided one.

--- a/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
@@ -68,7 +68,11 @@ namespace BoostTestAdapter.Boost.Runner
         {
             ProcessStartInfo info = base.GetStartInfo(args, settings);
 
-            CommandEvaluator evaluator = BuildEvaluator(this.Source, args, settings);
+            BoostTestRunnerCommandLineArgs tmpArgs = args.Clone();
+            tmpArgs.StandardErrorFile = null;
+            tmpArgs.StandardOutFile = null;
+
+            CommandEvaluator evaluator = BuildEvaluator(this.Source, tmpArgs, settings);
             CommandEvaluationResult result = evaluator.Evaluate(this.Settings.ExecutionCommandLine.Arguments);
             
             string cmdLineArgs = result.Result;
@@ -77,6 +81,13 @@ namespace BoostTestAdapter.Boost.Runner
                 cmdLineArgs = result.Result + (result.Result.EndsWith(" ", StringComparison.Ordinal) ? string.Empty : " ") + args.ToString();
             }
 
+            BoostTestRunnerCommandLineArgs redirection = new BoostTestRunnerCommandLineArgs
+            {
+                StandardOutFile = args.StandardOutFile,
+                StandardErrorFile = args.StandardErrorFile
+            };
+            cmdLineArgs += redirection.ToString();
+           
             info.FileName = this.Settings.ExecutionCommandLine.FileName;
             info.Arguments = cmdLineArgs;
 


### PR DESCRIPTION
Fixes `{boost-args}` evaluation when this 'macro' is used in between arguments e.g. `runner.exe --test {source} {boost-args} --custom_arg`.

This fix ensures that redirection operators are always appended at the end of the command line.