### PR TITLE
Utilise Convention over Configuration for Forced List Content

### DIFF
--- a/BoostTestAdapter/BoostTestDiscovererFactory.cs
+++ b/BoostTestAdapter/BoostTestDiscovererFactory.cs
@@ -9,11 +9,18 @@ using System.Linq;
 using BoostTestAdapter.Discoverers;
 using BoostTestAdapter.Boost.Runner;
 using BoostTestAdapter.Settings;
+using System;
 
 namespace BoostTestAdapter
 {
     class BoostTestDiscovererFactory : IBoostTestDiscovererFactory
     {
+        #region Constants
+
+        private static string ForceListContentExtension { get { return ".test.boostd.exe"; } }
+
+        #endregion 
+
         #region Constructors
 
         /// <summary>
@@ -153,7 +160,9 @@ namespace BoostTestAdapter
             };
 
             IBoostTestRunner runner = _factory.GetRunner(source, options);
-            return (runner != null) && runner.ListContentSupported;
+
+            // Convention over configuration. Assume test runners utilising such an extension
+            return (runner != null) && (runner.Source.EndsWith(ForceListContentExtension, StringComparison.OrdinalIgnoreCase) || runner.ListContentSupported);
         }
 
     }

--- a/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
+++ b/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
@@ -68,6 +68,9 @@ namespace BoostTestAdapterNunit
         [TestCase("test.exe", ListContentUse.ForceUse, ".exe", Result = typeof(ExternalDiscoverer))]
         [TestCase("test.listcontent.exe", ListContentUse.Use, ".exe", Result = typeof(ExternalDiscoverer))]
         [TestCase("test.listcontent.exe", ListContentUse.ForceUse, ".exe", Result = typeof(ExternalDiscoverer))]
+        // .test.boostd.exe
+        [TestCase("test.test.boostd.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.test.boostd.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
         // Dll types
         [TestCase("test.dll", ListContentUse.Use, null, Result = null)]
         [TestCase("test.dll", ListContentUse.Use, ".dll", Result = typeof(ExternalDiscoverer))]


### PR DESCRIPTION
Modules ending with the `.test.boostd.exe` extension are now assumed to be test modules which support `--list_content=DOT` by default. This avoids the need for users to define `.runsettings` file for such modules.