### PR TITLE
Remove the usage of the label trait so that multiple labels can be at…

### DIFF
--- a/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
+++ b/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
@@ -43,7 +43,7 @@ namespace BoostTestAdapter.Discoverers
         public string Source { get; private set; }
 
         /// <summary>
-        /// Whether the module should outut to the logger regarding relative paths
+        /// Whether the module should output to the logger regarding relative paths
         /// </summary>
         public bool OutputLog { get; private set; }
 
@@ -127,7 +127,7 @@ namespace BoostTestAdapter.Discoverers
                 foreach (string label in unit.Labels)
                 {
                     // Register each and every label as an individual trait
-                    test.Traits.Add(new Trait(VSTestModel.LabelTrait, ("@" + label)));
+                    test.Traits.Add(new Trait(label, ""));
                 }             
 
                 // Test cases inherit the labels of parent test units

--- a/BoostTestAdapterNunit/ListContentDiscovererTest.cs
+++ b/BoostTestAdapterNunit/ListContentDiscovererTest.cs
@@ -59,7 +59,7 @@ namespace BoostTestAdapterNunit
         private void AssertLabelTrait(VSTestCase testCase, string label)
         {
             Assert.That(testCase, Is.Not.Null);
-            Assert.That(testCase.Traits.Any((trait) => ((trait.Name == VSTestModel.LabelTrait) && (trait.Value == label))), Is.True);
+            Assert.That(testCase.Traits.Any((trait) => ((trait.Name == label) && (trait.Value.Length == 0))), Is.True);
         }
 
         #endregion Helper Methods
@@ -114,12 +114,12 @@ namespace BoostTestAdapterNunit
             // Ensure proper test discovery
             Assert.That(sink.Tests.Count, Is.EqualTo(8));
 
-            // Ensure proper labeling
-            const string label = "@l1";
-
-            AssertLabelTrait(sink.Tests.FirstOrDefault((vstest) => (vstest.FullyQualifiedName == "test_2")), label);
-            AssertLabelTrait(sink.Tests.FirstOrDefault((vstest) => (vstest.FullyQualifiedName == "test_6")), label);
-            AssertLabelTrait(sink.Tests.FirstOrDefault((vstest) => (vstest.FullyQualifiedName == "test_8")), label);
+            AssertLabelTrait(sink.Tests.FirstOrDefault((vstest) => (vstest.FullyQualifiedName == "test_2")), "l1");
+            AssertLabelTrait(sink.Tests.FirstOrDefault((vstest) => (vstest.FullyQualifiedName == "test_6")), "l1");
+            var test_8 = sink.Tests.FirstOrDefault((vstest) => (vstest.FullyQualifiedName == "test_8"));
+            AssertLabelTrait(test_8, "l1");
+            AssertLabelTrait(test_8, "l2");
+            AssertLabelTrait(test_8, "l3 withaspace");
 
             Assert.That(output, Is.Not.Null);
 

--- a/BoostTestAdapterNunit/Resources/ListContentDOT/sample.8.list.content.gv
+++ b/BoostTestAdapterNunit/Resources/ListContentDOT/sample.8.list.content.gv
@@ -15,6 +15,6 @@ tu65511[shape=Mrecord,fontname=Helvetica,color=yellow,label="test_6|d:\sample.bo
 tu1 -> tu65511;
 tu65512[shape=Mrecord,fontname=Helvetica,color=yellow,label="test_7|d:\sample.boostunittest\file_1.cpp(62)"];
 tu1 -> tu65512;
-tu65513[shape=Mrecord,fontname=Helvetica,color=yellow,label="test_8|d:\sample.boostunittest\file_1.cpp(62)|labels: @l1"];
+tu65513[shape=Mrecord,fontname=Helvetica,color=yellow,label="test_8|d:\sample.boostunittest\file_1.cpp(62)|labels: @l1 @l2 @l3 withaspace"];
 tu1 -> tu65513;
 }


### PR DESCRIPTION
…tributed to one test

If multiple traits of name "Label" (but different values) are provided
in the traits collection, VS will display only one of them.  (most
probably it is generating an unique collection).
Code is changed so that the label name is what was before the label
value. The new label value is an empty string.

This pull request is in relation to #160.

Hereunder please find the representation in the test explorer before and after the change.

![traits_view_before](https://cloud.githubusercontent.com/assets/13785378/19646846/aab940f6-99fb-11e6-9497-8bb1280035d9.png)

![traits_view_after](https://cloud.githubusercontent.com/assets/13785378/19646858/b90a76e8-99fb-11e6-95a6-16c7d9d799c9.png)
