### PR TITLE
Allow FileName to be Evaluated

### DIFF
--- a/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
@@ -88,7 +88,7 @@ namespace BoostTestAdapter.Boost.Runner
             };
             cmdLineArgs += redirection.ToString();
            
-            info.FilePath = this.Settings.ExecutionCommandLine.FileName;
+            info.FilePath = evaluator.Evaluate(this.Settings.ExecutionCommandLine.FileName).Result;
             info.Arguments = cmdLineArgs;
 
             return info;


### PR DESCRIPTION
When using an external test runner, provide the capability to allow the filename to be expanded/evaluated as well in a similar manner to how command line arguments are expanded. This is necessary to allow for configurations/use-cases using the following:

```xml
<?xml version="1.0" encoding="utf-8"?>
<RunSettings>

	<!-- Adapter Specific sections -->

	<!-- BoostTest adapter -->
	<BoostTest>
		<ExternalTestRunner type=".exe">
			<ExecutionCommandLine>{source} {boost-args} -- --custom-arg</ExecutionCommandLine>
		</ExternalTestRunner>
	</BoostTest>

</RunSettings>
```

This *abuses* the external test runner mechanism to allow the injection of custom command-line arguments. Assuming `source` is `C:\test.exe` and `boost-args` is `--list_content=DOT`, the command line would evaluate to: `"C:\test.exe" "--list_content=DOT" -- --custom-arg`.