### PR TITLE
Overwrite environment variables instead of appending to them

### DIFF
--- a/BoostTestAdapter/Utility/ExecutionContext/DefaultProcessExecutionContext.cs
+++ b/BoostTestAdapter/Utility/ExecutionContext/DefaultProcessExecutionContext.cs
@@ -118,8 +118,7 @@ namespace BoostTestAdapter.Utility.ExecutionContext
                     // Sets variable accordingly to the environment
                     if (startInfo.EnvironmentVariables.ContainsKey(variable.Key))
                     {
-                        string value = startInfo.EnvironmentVariables[variable.Key];
-                        startInfo.EnvironmentVariables[variable.Key] = string.IsNullOrEmpty(value) ? variable.Value : (value + ';' + variable.Value);
+                        startInfo.EnvironmentVariables[variable.Key] = variable.Value;
                     }
                     else
                     {


### PR DESCRIPTION
As discussed in #169: the environment variables defined by user in the project should not be appended to the original values but overwrite them. 