### PR TITLE
Refactor Log Entry Structures

### DIFF
--- a/BoostTestAdapter/Boost/Results/BoostConsoleOutputBase.cs
+++ b/BoostTestAdapter/Boost/Results/BoostConsoleOutputBase.cs
@@ -5,6 +5,8 @@
 
 using System.IO;
 using System.Text.RegularExpressions;
+
+using BoostTestAdapter.Utility;
 using BoostTestAdapter.Boost.Results.LogEntryTypes;
 
 namespace BoostTestAdapter.Boost.Results
@@ -202,20 +204,15 @@ namespace BoostTestAdapter.Boost.Results
 
                     if (matchLeakInformation.Groups[1].Success && matchLeakInformation.Groups[2].Success && matchLeakInformation.Groups[3].Success)
                     {
-                        leak.LeakSourceFilePath = matchLeakInformation.Groups[1].Value;
+                        // Group 1 => Directory
+                        // Group 2 => Source File Name
 
-                        leak.LeakSourceFileName = matchLeakInformation.Groups[2].Value;
+                        leak.Source = new SourceFileInfo(matchLeakInformation.Groups[1].Value + matchLeakInformation.Groups[2].Value);
 
                         if (uint.TryParse(matchLeakInformation.Groups[3].Value, out value))
                         {
-                            leak.LeakLineNumber = value;
+                            leak.Source.LineNumber = (int) value;
                         }
-
-                        leak.LeakSourceFileAndLineNumberReportingActive = true;
-                    }
-                    else
-                    {
-                        leak.LeakSourceFileAndLineNumberReportingActive = false;
                     }
 
                     if (uint.TryParse(matchLeakInformation.Groups[4].Value, out value))

--- a/BoostTestAdapter/Boost/Results/BoostStandardError.cs
+++ b/BoostTestAdapter/Boost/Results/BoostStandardError.cs
@@ -35,7 +35,10 @@ namespace BoostTestAdapter.Boost.Results
 
         protected override LogEntry CreateLogEntry(string message)
         {
-            return new LogEntryStandardErrorMessage(message);
+            return new LogEntryStandardErrorMessage()
+            {
+                Detail = message
+            };
         }
 
         #endregion BoostConsoleOutputBase        

--- a/BoostTestAdapter/Boost/Results/BoostStandardOutput.cs
+++ b/BoostTestAdapter/Boost/Results/BoostStandardOutput.cs
@@ -39,7 +39,10 @@ namespace BoostTestAdapter.Boost.Results
 
         protected override LogEntry CreateLogEntry(string message)
         {
-            return new LogEntryStandardOutputMessage(message);
+            return new LogEntryStandardOutputMessage()
+            {
+                Detail = message
+            };
         }
 
         #endregion BoostConsoleOutputBase

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntry.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntry.cs
@@ -3,6 +3,9 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
+using System.Linq;
+using System.Collections.Generic;
+
 using BoostTestAdapter.Utility;
 
 namespace BoostTestAdapter.Boost.Results.LogEntryTypes
@@ -19,24 +22,60 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         /// </summary>
         protected LogEntry()
         {
+            Detail = string.Empty;
+            Source = null;
+            ContextFrames = Enumerable.Empty<string>();
         }
-
-        /// <summary>
-        /// Constructor accepting a SourceFileInfo
-        /// </summary>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        protected LogEntry(SourceFileInfo source) :
-            this()
-        {
-            this.Source = source;
-        }
-
-        #endregion Constructors
+        
+        #endregion
 
         /// <summary>
         /// Source file information related to this log message. May be null.
         /// </summary>
         public SourceFileInfo Source { get; set; }
+
+        /// <summary>
+        /// Log detail message.
+        /// </summary>
+        public string Detail { get; set; }
+
+        /// <summary>
+        /// Context frame information.
+        /// </summary>
+        public IEnumerable<string> ContextFrames { get; set; }
+
+        /// <summary>
+        /// Constructs a LogEntry and populates the main components
+        /// </summary>
+        /// <typeparam name="T">A derived LogEntry class type</typeparam>
+        /// <param name="detail">The detail message. 'null' to use the default.</param>
+        /// <param name="source">The source file information assocaited to the log entry. 'null' to use the default.</param>
+        /// <param name="context">The log entry context. 'null' to use the default.</param>
+        /// <returns>A new LogEntry-derived instance populated accordingly</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1026:DefaultParametersShouldNotBeUsed")]
+        public static T MakeLogEntry<T>(string detail = null, SourceFileInfo source = null, IEnumerable<string> context = null) where T : LogEntry, new()
+        {
+            T entry = new T();
+
+            if (detail != null)
+            {
+                entry.Detail = detail;
+            }
+
+            if (source != null)
+            {
+                entry.Source = source;
+            }
+
+            if (context != null)
+            {
+                entry.ContextFrames = context;
+            }
+
+            return entry;
+        }
+
+        #region Object overrides
 
         /// <summary>
         /// returns a string with the description of the class
@@ -47,9 +86,6 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
             return "Base";
         }
 
-        /// <summary>
-        /// Log detail message.
-        /// </summary>
-        public string Detail { get; set; }
+        #endregion
     }
 }

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryError.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryError.cs
@@ -3,10 +3,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-using System.Linq;
-using System.Collections.Generic;
-using BoostTestAdapter.Utility;
-
 namespace BoostTestAdapter.Boost.Results.LogEntryTypes
 {
     /// <summary>
@@ -20,50 +16,11 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         /// Default constructor
         /// </summary>
         public LogEntryError()
-            : this(string.Empty)
         {
         }
-
-        /// <summary>
-        /// Constructor accepting a detail message
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        public LogEntryError(string detail)
-            : this(detail, null)
-        {
-        }
-
-        /// <summary>
-        /// Constructor accepting a detail message and a SourceFileInfo object
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        public LogEntryError(string detail, SourceFileInfo source)
-            : this(detail, source, Enumerable.Empty<string>())
-        {
-        }
-
-
-        /// <summary>
-        /// Constructor accepting a detail message, a SourceFileInfo object and error context frames
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        /// <param name="contextFrames">Error context frame information related to this error message. May be empty.</param>
-        public LogEntryError(string detail, SourceFileInfo source, IEnumerable<string> contextFrames)
-            : base(source)
-        {
-            this.Detail = detail;
-            this.ContextFrames = contextFrames;
-        }
-
+        
         #endregion Constructors
 
-        /// <summary>
-        /// Context frame information.
-        /// </summary>
-        public IEnumerable<string> ContextFrames { get; set; }
-        
         /// <summary>
         /// returns a string with the description of the class
         /// </summary>

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryException.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryException.cs
@@ -14,31 +14,13 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
     {
         #region Constructors
 
-        public LogEntryException() :
-            this(null)
-        {
-        }
-
         /// <summary>
-        /// Constructor accepting a detail message of type string
+        /// Default Constructor
         /// </summary>
-        /// <param name="detail">Exception detail message</param>
-        public LogEntryException(string detail) :
-            this(detail, null)
+        public LogEntryException()
         {
         }
-
-        /// <summary>
-        /// Constructor accepting an exception detail message and a SourceFileInfo object
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        public LogEntryException(string detail, SourceFileInfo source)
-            : base(source)
-        {
-            this.Detail = detail;
-        }
-
+        
         #endregion Constructors
 
         /// <summary>

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryFatalError.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryFatalError.cs
@@ -15,25 +15,12 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         #region Constructors
 
         /// <summary>
-        /// Constructor accepting a detail message of type string
+        /// Default Constructor
         /// </summary>
-        /// <param name="detail">Exception detail message</param>
-        public LogEntryFatalError(string detail)
+        public LogEntryFatalError()
         {
-            this.Detail = detail;
         }
-
-        /// <summary>
-        /// Constructor accepting a detail message and a SourceFileInfo object
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        public LogEntryFatalError(string detail, SourceFileInfo source)
-            : base(source)
-        {
-            this.Detail = detail;
-        }
-
+        
         #endregion Constructors
 
         /// <summary>

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryInfo.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryInfo.cs
@@ -3,8 +3,6 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-using BoostTestAdapter.Utility;
-
 namespace BoostTestAdapter.Boost.Results.LogEntryTypes
 {
     /// <summary>
@@ -15,25 +13,12 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         #region Constructors
 
         /// <summary>
-        /// Constructor accepting a detail message of type string
+        /// Default Constructor
         /// </summary>
-        /// <param name="detail">Exception detail message</param>
-        public LogEntryInfo(string detail)
+        public LogEntryInfo()
         {
-            this.Detail = detail;
         }
-
-        /// <summary>
-        /// Constructor accepting a detail message and a SourceFileInfo object
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        public LogEntryInfo(string detail, SourceFileInfo source)
-            : base(source)
-        {
-            this.Detail = detail;
-        }
-
+        
         #endregion Constructors
 
         /// <summary>

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryMemoryLeak.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryMemoryLeak.cs
@@ -21,27 +21,7 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         /// </summary>
         public LogEntryMemoryLeak()
         {
-            this.Detail = MemoryLeakNotification;
-        }
-
-        /// <summary>
-        /// Constructor accepting a SourceFileInfo object
-        /// </summary>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        public LogEntryMemoryLeak(SourceFileInfo source)
-            : base(source)
-        {
-        }
-
-        public LogEntryMemoryLeak(string leakSourceFilePath, string leakSourceFileName, uint? leakLineNumber, uint? leakSizeInBytes, uint? leakMemoryAllocationNumber, string leakLeakedDataContents)
-        {
-            this.LeakSourceFilePath = leakSourceFilePath;
-            this.LeakSourceFileName = leakSourceFileName;
-            this.LeakLineNumber = leakLineNumber;
-            this.LeakSizeInBytes = leakSizeInBytes;
-            this.LeakMemoryAllocationNumber = leakMemoryAllocationNumber;
-            this.LeakLeakedDataContents = leakLeakedDataContents;
-            this.Detail = MemoryLeakNotification;
+            Detail = MemoryLeakNotification;
         }
 
         #endregion Constructors
@@ -54,25 +34,7 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         {
             return "Memory leak";
         }
-
-        /// <summary>
-        /// Indicates the source file path where the leak was detected at
-        /// </summary>
-        /// <remarks>If null, the information regarding the leak source file path is not available.  This generally is because the macro to replace the C++ operator new has not been utilized in the test project.</remarks>
-        public string LeakSourceFilePath { get; set; }
-
-        /// <summary>
-        /// Indicates the source filename where the leak was detected at
-        /// </summary>
-        /// <remarks>If null, the information regarding the leak source file name is not available.  This generally is because the macro to replace the C++ operator new has not been utilized in the test project.</remarks>
-        public string LeakSourceFileName { get; set; }
-
-        /// <summary>
-        /// Line number (respective the source file specified in property LeakSourceFileName) where the leak is detected at
-        /// </summary>
-        /// <remarks>If null, the information regarding the leak line number is not available.  This generally is because the macro to replace the C++ operator new has not been utilized in the test project, or the parsing of the line number failed.</remarks>
-        public uint? LeakLineNumber { get; set; }
-
+        
         /// <summary>
         /// Number of bytes leaked.
         /// </summary>
@@ -91,8 +53,22 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         public string LeakLeakedDataContents { get; set; }
 
         /// <summary>
-        /// Property serves as an indicator wheather the source file and the line number information for the memory leak were available or not
+        /// Constructs a LogEntryMemoryLeak and populates the main components
         /// </summary>
-        public bool LeakSourceFileAndLineNumberReportingActive { get; set; }
+        /// <param name="leakLocation">The location of the memory leak.</param>
+        /// <param name="leakSizeInBytes">The number of bytes leaked.</param>
+        /// <param name="leakMemoryAllocationNumber">The memory allocation number.</param>
+        /// <param name="leakLeakedDataContents">The memory contents which were leaked.</param>
+        /// <returns>A new LogEntryMemoryLeak instance populated accordingly</returns>
+        public static LogEntryMemoryLeak MakeLogEntryMemoryLeak(SourceFileInfo leakLocation, uint? leakSizeInBytes, uint? leakMemoryAllocationNumber, string leakLeakedDataContents)
+        {
+            return new LogEntryMemoryLeak()
+            {
+                Source = leakLocation,
+                LeakSizeInBytes = leakSizeInBytes,
+                LeakMemoryAllocationNumber = leakMemoryAllocationNumber,
+                LeakLeakedDataContents = leakLeakedDataContents
+            };
+        }
     }
 }

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryMessage.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryMessage.cs
@@ -15,25 +15,12 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         #region Constructors
 
         /// <summary>
-        /// Constructor accepting a detail message
+        /// Default Constructor
         /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        public LogEntryMessage(string detail)
+        public LogEntryMessage()
         {
-            this.Detail = detail;
         }
-
-        /// <summary>
-        /// Constructor accepting a detail message and a SourceFileInfo object
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        public LogEntryMessage(string detail, SourceFileInfo source)
-            : base(source)
-        {
-            this.Detail = detail;
-        }
-
+        
         #endregion Constructors
 
         /// <summary>

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryStandardErrorMessage.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryStandardErrorMessage.cs
@@ -12,9 +12,11 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
     {
         #region Constructors
 
-        public LogEntryStandardErrorMessage(string detail)
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public LogEntryStandardErrorMessage()
         {
-            this.Detail = detail;
         }
 
         #endregion Constructors

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryStandardOutputMessage.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryStandardOutputMessage.cs
@@ -12,9 +12,11 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
     {
         #region Constructors
 
-        public LogEntryStandardOutputMessage(string detail)
+        /// <summary>
+        /// Default Constructor
+        /// </summary>
+        public LogEntryStandardOutputMessage()
         {
-            this.Detail = detail;
         }
 
         #endregion Constructors

--- a/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryWarning.cs
+++ b/BoostTestAdapter/Boost/Results/LogEntryTypes/LogEntryWarning.cs
@@ -15,25 +15,12 @@ namespace BoostTestAdapter.Boost.Results.LogEntryTypes
         #region Constructors
 
         /// <summary>
-        /// Constructor accepting a detail message
+        /// Default Constructor
         /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        public LogEntryWarning(string detail)
+        public LogEntryWarning()
         {
-            this.Detail = detail;
         }
-
-        /// <summary>
-        /// Constructor accepting a detail message and a SourceFileInfo object
-        /// </summary>
-        /// <param name="detail">detail message of type string</param>
-        /// <param name="source">Source file information related to this log message. May be null.</param>
-        public LogEntryWarning(string detail, SourceFileInfo source)
-            : base(source)
-        {
-            this.Detail = detail;
-        }
-
+        
         #endregion Constructors
 
         /// <summary>

--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -528,7 +528,10 @@ namespace BoostTestAdapter
                         exception.Duration = ((ulong)(end - start).Ticks) / 10;
 
                         exception.Result = TestResultType.Failed;
-                        exception.LogEntries.Add(new Boost.Results.LogEntryTypes.LogEntryFatalError(text));
+                        exception.LogEntries.Add(new Boost.Results.LogEntryTypes.LogEntryFatalError()
+                        {
+                            Detail = text
+                        });
 
                         return GenerateResult(test, exception, start, end);
                     });

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -239,10 +239,9 @@ namespace BoostTestAdapter.Utility.VisualStudio
                 FormatException(exception, sb);
             }
 
-            LogEntryError error = entry as LogEntryError;
-            if (error != null)
+            if ((entry.ContextFrames != null) && (entry.ContextFrames.Any()))
             {
-                FormatError(error, sb);
+                FormatContextFrames(entry, sb);
             }
 
             if (memoryLeak != null)
@@ -273,28 +272,25 @@ namespace BoostTestAdapter.Utility.VisualStudio
         }
 
         /// <summary>
-        /// Formats a LogEntryException to append to test result string
+        /// Formats the context frames of a LogEntry and appends it to test result string
         /// </summary>
-        /// <param name="error">The error to format</param>
+        /// <param name="entry">The log entry to format</param>
         /// <param name="sb">The StringBuilder which will host the output</param>
         /// <returns>sb</returns>
-        private static StringBuilder FormatError(LogEntryError error, StringBuilder sb)
+        private static StringBuilder FormatContextFrames(LogEntry entry, StringBuilder sb)
         {
-            if (error.ContextFrames != null)
+            sb.Append(Environment.NewLine).
+                Append("Occurred in a following context:").
+                Append(Environment.NewLine);
+
+            foreach (string frame in entry.ContextFrames)
             {
-                sb.Append(Environment.NewLine).
-                    Append("Failure occurred in a following context:").
-                    Append(Environment.NewLine);
-
-                foreach (string frame in error.ContextFrames)
-                {
-                    sb.Append("    ").Append(frame).Append(Environment.NewLine);
-                }
-
-                // Remove redundant NewLine at the end
-                sb.Remove((sb.Length - Environment.NewLine.Length), Environment.NewLine.Length);
+                sb.Append("    ").Append(frame).Append(Environment.NewLine);
             }
 
+            // Remove redundant NewLine at the end
+            sb.Remove((sb.Length - Environment.NewLine.Length), Environment.NewLine.Length);
+            
             return sb;
         }
 
@@ -306,26 +302,22 @@ namespace BoostTestAdapter.Utility.VisualStudio
         /// <returns>sb</returns>
         private static StringBuilder FormatMemoryLeak(LogEntryMemoryLeak memoryLeak, StringBuilder sb)
         {
-            if ((memoryLeak.LeakSourceFilePath != null) && (memoryLeak.LeakSourceFileName != null))
+            if (memoryLeak.Source != null)
             {
                 sb.Append("source file path leak detected at :").
-                    Append(memoryLeak.LeakSourceFilePath).
-                    Append(memoryLeak.LeakSourceFileName);
-            }
+                    Append(memoryLeak.Source.File);
 
-            if (memoryLeak.LeakLineNumber != null)
-            {
-                sb.Append(", ").
-                    Append("Line number: ").
-                    Append(memoryLeak.LeakLineNumber);
+                if (memoryLeak.Source.LineNumber != -1)
+                {
+                    sb.Append(", Line number: ").
+                        Append(memoryLeak.Source.LineNumber);
+                }
             }
-
-            sb.Append(", ").
-                Append("Memory allocation number: ").
+            
+            sb.Append(", Memory allocation number: ").
                 Append(memoryLeak.LeakMemoryAllocationNumber);
 
-            sb.Append(", ").
-                Append("Leak size: ").
+            sb.Append(", Leak size: ").
                 Append(memoryLeak.LeakSizeInBytes).
                 Append(" byte");
 

--- a/BoostTestAdapterNunit/VSTestModelTest.cs
+++ b/BoostTestAdapterNunit/VSTestModelTest.cs
@@ -247,6 +247,19 @@ namespace BoostTestAdapterNunit
             return result.Messages.First().Category;
         }
 
+        /// <summary>
+        /// Constructs a LogEntry and populates the main components
+        /// </summary>
+        /// <typeparam name="T">A derived LogEntry class type</typeparam>
+        /// <param name="detail">The detail message. 'null' to use the default.</param>
+        /// <param name="source">The source file information assocaited to the log entry. 'null' to use the default.</param>
+        /// <param name="context">The log entry context. 'null' to use the default.</param>
+        /// <returns>A new LogEntry-derived instance populated accordingly</returns>
+        private T MakeLogEntry<T>(string detail = null, SourceFileInfo source = null, IEnumerable<string> context = null) where T : LogEntry, new()
+        {
+            return LogEntry.MakeLogEntry<T>(detail, source, context);
+        }
+
         #endregion Helper Methods
 
         #region Tests
@@ -264,7 +277,7 @@ namespace BoostTestAdapterNunit
                 For(this.TestCase).
                 Passed().
                 Duration(1000).
-                Log(new LogEntryMessage("BOOST_MESSAGE output")).
+                Log(MakeLogEntry<LogEntryMessage>("BOOST_MESSAGE output")).
                 Build();
 
             VSTestResult result = testCaseResult.AsVSTestResult(this.TestCase);
@@ -289,7 +302,7 @@ namespace BoostTestAdapterNunit
         [Test]
         public void ConvertFailToVSTestResult()
         {
-            LogEntryError error = new LogEntryError("Error: 1 != 2", new SourceFileInfo("file.cpp", 10));
+            LogEntryError error = MakeLogEntry<LogEntryError>("Error: 1 != 2", new SourceFileInfo("file.cpp", 10));
 
             BoostTestResult testCaseResult = new BoostTestResultBuilder().
                 For(this.TestCase).
@@ -346,7 +359,7 @@ namespace BoostTestAdapterNunit
         [Test]
         public void ConvertExceptionToVSTestResult()
         {
-            LogEntryException exception = new LogEntryException("C string: some error", new SourceFileInfo("unknown location", 0));
+            LogEntryException exception = MakeLogEntry<LogEntryException>("C string: some error", new SourceFileInfo("unknown location", 0));
             exception.LastCheckpoint = new SourceFileInfo("boostunittestsample.cpp", 13);
             exception.CheckpointDetail = "Going to throw an exception";
 
@@ -384,15 +397,12 @@ namespace BoostTestAdapterNunit
         [Test]
         public void ConvertMemoryLeakToVSTestResult()
         {
-            LogEntryMemoryLeak leak = new LogEntryMemoryLeak();
+            LogEntryMemoryLeak leak = MakeLogEntry<LogEntryMemoryLeak>();
 
-            leak.LeakLineNumber = 32;
+            leak.Source = new SourceFileInfo(@"C:\boostunittestsample.cpp", 32);
             leak.LeakMemoryAllocationNumber = 836;
             leak.LeakLeakedDataContents = " Data: <`-  Leak...     > 60 2D BD 00 4C 65 61 6B 2E 2E 2E 00 CD CD CD CD ";
-
-            leak.LeakSourceFilePath = @"C:\boostunittestsample.cpp";
-            leak.LeakSourceFileName = "boostunittestsample.cpp";
-
+            
             BoostTestResult testCaseResult = new BoostTestResultBuilder().
                 For(this.TestCase).
                 Passed().
@@ -423,17 +433,17 @@ namespace BoostTestAdapterNunit
         public void TestLogEntryCategory()
         {
             // Standard Output
-            Assert.That(GetCategory(new LogEntryInfo("Info")), Is.EqualTo(TestResultMessage.StandardOutCategory));
-            Assert.That(GetCategory(new LogEntryMessage("Message")), Is.EqualTo(TestResultMessage.StandardOutCategory));
-            Assert.That(GetCategory(new LogEntryStandardOutputMessage("StdOut")), Is.EqualTo(TestResultMessage.StandardOutCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryInfo>("Info")), Is.EqualTo(TestResultMessage.StandardOutCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryMessage>("Message")), Is.EqualTo(TestResultMessage.StandardOutCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryStandardOutputMessage>("StdOut")), Is.EqualTo(TestResultMessage.StandardOutCategory));
 
             // Standard Error
-            Assert.That(GetCategory(new LogEntryWarning("Warning")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
-            Assert.That(GetCategory(new LogEntryError("Error")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
-            Assert.That(GetCategory(new LogEntryFatalError("FatalError")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
-            Assert.That(GetCategory(new LogEntryException("Exception")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
-            Assert.That(GetCategory(new LogEntryMemoryLeak()), Is.EqualTo(TestResultMessage.StandardErrorCategory));
-            Assert.That(GetCategory(new LogEntryStandardErrorMessage("StdErr")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryWarning>("Warning")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryError>("Error")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryFatalError>("FatalError")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryException>("Exception")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryMemoryLeak>()), Is.EqualTo(TestResultMessage.StandardErrorCategory));
+            Assert.That(GetCategory(MakeLogEntry<LogEntryStandardErrorMessage>("StdErr")), Is.EqualTo(TestResultMessage.StandardErrorCategory));
         }
 
         #endregion Tests


### PR DESCRIPTION
Refactoring exercise over log entry types. Tries to simplify the structure of the types themselves.

In addition, all log entries can now be assigned a context, allowing context to be visible for non-error log entry types as well.