### PR TITLE
Add Configurable Post Test Batch Delay

### DIFF
--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -8,20 +8,23 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
+using System.Threading;
+using System.Runtime.InteropServices;
+
+using Microsoft.VisualStudio.TestPlatform.ObjectModel;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
+using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
+using VSTestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
+
 using BoostTestAdapter.Boost.Results;
 using BoostTestAdapter.Boost.Runner;
 using BoostTestAdapter.Settings;
 using BoostTestAdapter.TestBatch;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Adapter;
-using Microsoft.VisualStudio.TestPlatform.ObjectModel.Logging;
 using BoostTestAdapter.Utility;
 using BoostTestAdapter.Utility.VisualStudio;
-using System.Runtime.InteropServices;
-using VSTestCase = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestCase;
-using VSTestResult = Microsoft.VisualStudio.TestPlatform.ObjectModel.TestResult;
-using BoostTestResult = BoostTestAdapter.Boost.Results.TestResult;
 using BoostTestAdapter.Utility.ExecutionContext;
+using BoostTestResult = BoostTestAdapter.Boost.Results.TestResult;
 
 namespace BoostTestAdapter
 {
@@ -362,6 +365,11 @@ namespace BoostTestAdapter
                         // Execute the tests
                         if (ExecuteTests(batch, runContext, frameworkHandle))
                         {
+                            if (settings.PostTestDelay > 0)
+                            {
+                                Thread.Sleep(settings.PostTestDelay);
+                            }
+
                             foreach (VSTestResult result in GenerateTestResults(batch, start, settings))
                             {
                                 // Identify test result to Visual Studio Test framework

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -56,12 +56,17 @@ namespace BoostTestAdapter.Settings
             this.RunDisabledTests = false;
 
             this.TestRunnerFactoryOptions = new BoostTestRunnerFactoryOptions();
+
+            this.PostTestDelay = 0;
         }
 
         #region Properties
 
         #region Serialisable Fields
 
+        /// <summary>
+        /// Specifies the duration in milliseconds test process are allowed to execute until forcibly terminated. Use '-1' to allow tests to execute indefinitely.
+        /// </summary>
         [DefaultValue(-1)]
         public int ExecutionTimeoutMilliseconds
         {
@@ -76,15 +81,27 @@ namespace BoostTestAdapter.Settings
             }
         }
 
+        /// <summary>
+        /// Specifies the duration in milliseconds test process are allowed to execute in order to have their list_content output analyzed until forcibly terminated.
+        /// </summary>
         [DefaultValue(30000)]
         public int DiscoveryTimeoutMilliseconds { get; set; }
 
+        /// <summary>
+        /// Set to 'true'|'1' to fail tests in case memory leaks are detected.
+        /// </summary>
         [DefaultValue(false)]
         public bool FailTestOnMemoryLeak { get; set; }
 
+        /// <summary>
+        /// Specify Boost Test log verbosity.
+        /// </summary>
         [DefaultValue(LogLevel.TestSuite)]
         public LogLevel LogLevel { get; set; }
 
+        /// <summary>
+        /// Set to 'true'|'1' to enable Boost Test's catch_system_errors.
+        /// </summary>
         [DefaultValue(true)]
         public bool CatchSystemErrors
         {
@@ -99,6 +116,9 @@ namespace BoostTestAdapter.Settings
             }
         }
 
+        /// <summary>
+        /// Set to 'true'|'1' to enable Boost Test's detect_fp_exceptions.
+        /// </summary>
         [DefaultValue(false)]
         public bool DetectFloatingPointExceptions
         {
@@ -113,6 +133,9 @@ namespace BoostTestAdapter.Settings
             }
         }
 
+        /// <summary>
+        /// Describes the discovery and test execution mechanisms for Boost Test executables using a custom runner implementation.
+        /// </summary>
         public ExternalBoostTestRunnerSettings ExternalTestRunner
         {
             get
@@ -126,23 +149,44 @@ namespace BoostTestAdapter.Settings
             }
         }
 
+        /// <summary>
+        /// Determines how tests should be grouped for execution.
+        /// </summary>
         [DefaultValue(TestBatch.Strategy.TestCase)]
         public TestBatch.Strategy TestBatchStrategy { get; set; }
 
+        /// <summary>
+        /// Forces the use of 'list_content=DOT' even if the test module is not recognized as a safe module.
+        /// </summary>
         [DefaultValue(false)]
         public bool ForceListContent { get; set; }
 
+        /// <summary>
+        /// Determines the working directory which is to be used during the discovery/execution of the test module. If the test module is executed within a Visual Studio test adapter session, the Working Directory defined in the 'Debug' property sheet configuration overrides this value.
+        /// </summary>
         [DefaultValue(null)]
         public string WorkingDirectory { get; set; }
-        
+
+        /// <summary>
+        /// Enables/Disables standard output redirection. Note that if disabled, memory leak detection is implicitly disabled.
+        /// </summary>
         [DefaultValue(true)]
         public bool EnableStdOutRedirection { get; set; }
 
+        /// <summary>
+        /// Enables/Disables standard error redirection.
+        /// </summary>
         [DefaultValue(true)]
         public bool EnableStdErrRedirection { get; set; }
 
+        /// <summary>
+        /// Define a series of regular expression patterns which determine which test modules should be taken into consideration for discovery/execution.
+        /// </summary>
         public TestSourceFilter Filters { get; set; }
 
+        /// <summary>
+        /// Enables/Disables the Boost 1.62 workaround. Allows the use of the test adapter with Boost Test released with Boost 1.62.
+        /// </summary>
         [DefaultValue(false)]
         public bool UseBoost162Workaround
         {
@@ -157,19 +201,37 @@ namespace BoostTestAdapter.Settings
             }
         }
 
+        /// <summary>
+        /// Set to 'true'|'1' to force explicitly disabled tests to be run with any other enabled tests if "Run all..." is pressed. By default, only enabled tests are run.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool RunDisabledTests { get; set; }
+
+        /// <summary>
+        /// Determines a delay represented in milliseconds which will be forced after the execution of each test batch.
+        /// </summary>
+        [DefaultValue(0)]
+        public int PostTestDelay { get; set; }
+
         #endregion Serialisable Fields
 
+        /// <summary>
+        /// Internal Test Runner Settings. Serializable properties implicitly populate this instance.
+        /// </summary>
         [XmlIgnore]
         public BoostTestRunnerSettings TestRunnerSettings { get; private set; }
 
+        /// <summary>
+        /// Internal Command Line Arguments. Serializable properties implicitly populate this instance.
+        /// </summary>
         [XmlIgnore]
         public BoostTestRunnerCommandLineArgs CommandLineArgs { get; private set; }
 
+        /// <summary>
+        /// Internal Test Runner Factory Options. Serializable properties implicitly populate this instance.
+        /// </summary>
         [XmlIgnore]
         public BoostTestRunnerFactoryOptions TestRunnerFactoryOptions { get; private set; }
-
-        [DefaultValue(false)]
-        public bool RunDisabledTests { get; set; }
 
         #endregion Properties
 

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -69,6 +69,7 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.Filters, Is.EqualTo(TestSourceFilter.Empty));
             Assert.That(settings.RunDisabledTests, Is.False);
             Assert.That(settings.UseBoost162Workaround, Is.False);
+            Assert.That(settings.PostTestDelay, Is.EqualTo(0));
         }
         
         #endregion Helper Methods
@@ -174,6 +175,23 @@ namespace BoostTestAdapterNunit
         {
             BoostTestAdapterSettings settings = ParseXml(settingsXml);
             return settings.UseBoost162Workaround;
+        }
+
+        /// <summary>
+        /// The 'PostTestDelay' option can be properly parsed
+        /// 
+        /// Test aims:
+        ///     - Assert that: the 'PostTestDelay' option can be properly parsed
+        /// </summary>
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><PostTestDelay>0</PostTestDelay></BoostTest></RunSettings>", Result = 0)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><PostTestDelay>-2147483648</PostTestDelay></BoostTest></RunSettings>", Result = -2147483648)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><PostTestDelay>2147483647</PostTestDelay></BoostTest></RunSettings>", Result = 2147483647)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><PostTestDelay>15</PostTestDelay></BoostTest></RunSettings>", Result = 15)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest /></RunSettings>", Result = 0)]
+        public int ParsePostTestDelayOption(string settingsXml)
+        {
+            BoostTestAdapterSettings settings = ParseXml(settingsXml);
+            return settings.PostTestDelay;
         }
 
         #endregion Tests


### PR DESCRIPTION
Introduced a new `<PostTestDelay>` configuration option which allows users to specify a delay time in milliseconds which is applied at the end of each test batch execution (before result parsing).

Closes #176