### PR TITLE
Log Boost.Test Exit Code in Case of Failure During Discovery

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
@@ -43,7 +43,7 @@ namespace BoostTestAdapter.Boost.Runner
 
         public string Source => this.Runner.Source;
 
-        public void Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)
+        public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)
         {
             var fixedArgs = args;
 
@@ -55,7 +55,7 @@ namespace BoostTestAdapter.Boost.Runner
 
             using (var stderr = new TemporaryFile(IsStandardErrorFileDifferent(args, fixedArgs) ? fixedArgs.StandardErrorFile : null))
             {
-                this.Runner.Execute(fixedArgs, settings, executionContext);
+                int resultCode = this.Runner.Execute(fixedArgs, settings, executionContext);
 
                 // Extract the report output to its intended location
                 string source = (fixedArgs == null) ? null : fixedArgs.StandardErrorFile;
@@ -72,6 +72,8 @@ namespace BoostTestAdapter.Boost.Runner
                         Logger.Exception(ex, "Failed to extract test report from standard error [{0}] to report file [{1}] ({2})", source, destination, ex.Message);
                     }
                 }
+
+                return resultCode;
             }
         }
 

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -44,14 +44,14 @@ namespace BoostTestAdapter.Boost.Runner
 
         #region IBoostTestRunner
 
-        public virtual void Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)
+        public virtual int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)
         {
             Utility.Code.Require(settings, "settings");
             Utility.Code.Require(executionContext, "executionContext");
 
             using (Process process = executionContext.LaunchProcess(GetExecutionContextArgs(args, settings)))
             {
-                MonitorProcess(process, settings.Timeout);
+                return MonitorProcess(process, settings.Timeout);
             }
         }
         
@@ -120,7 +120,7 @@ namespace BoostTestAdapter.Boost.Runner
         /// <param name="process">The process to monitor.</param>
         /// <param name="timeout">The timeout threshold until the process and its children should be killed.</param>
         /// <exception cref="TimeoutException">Thrown in case specified timeout threshold is exceeded.</exception>
-        private static void MonitorProcess(Process process, int timeout)
+        private static int MonitorProcess(Process process, int timeout)
         {
             process.WaitForExit(timeout);
 
@@ -130,6 +130,8 @@ namespace BoostTestAdapter.Boost.Runner
 
                 throw new TimeoutException(timeout);
             }
+
+            return process.ExitCode;
         }
         
         /// <summary>

--- a/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
@@ -18,8 +18,9 @@ namespace BoostTestAdapter.Boost.Runner
         /// <param name="args">The Boost Test framework command line options.</param>
         /// <param name="settings">The Boost Test runner settings.</param>
         /// <param name="executionContext">An IProcessExecutionContext which will manage any spawned process.</param>
+        /// <returns>Boost.Test result code</returns>
         /// <exception cref="TimeoutException">Thrown in case specified timeout threshold is exceeded.</exception>
-        void Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext);
+        int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext);
         
         /// <summary>
         /// Provides a source Id distinguishing different instances

--- a/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
+++ b/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
@@ -126,9 +126,10 @@ namespace BoostTestAdapterNunit
 
         public string Source { get; private set; }
 
-        public void Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext context)
+        public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext context)
         {
             Copy("BoostTestAdapterNunit.Resources.ListContentDOT.sample.8.list.content.gv", args.StandardErrorFile);
+            return 0;
         }
 
         private void Copy(string embeddedResource, string path)

--- a/BoostTestAdapterNunit/BoostTestExecutorTest.cs
+++ b/BoostTestAdapterNunit/BoostTestExecutorTest.cs
@@ -302,7 +302,7 @@ namespace BoostTestAdapterNunit
 
             #region IBoostTestRunner
             
-            public void Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext context)
+            public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext context)
             {
                 this.ExecutionArgs.Add(new MockBoostTestRunnerExecutionArgs()
                 {
@@ -346,6 +346,8 @@ namespace BoostTestAdapterNunit
                     Copy(resources.ReportFilePath, args.ReportFile);
                     Copy(resources.LogFilePath, args.LogFile);
                 }
+
+                return 0;
             }
 
             public string Source { get; private set; }


### PR DESCRIPTION
The exit code of the Boost.Test executable is now logged in case of error to better identify issues during discovery. This should provide hints to the user in case discovery fails for a certain project/source.

Addresses issue #187.