### PR TITLE
"BUTA" environment variable set during an execution context

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -228,7 +228,17 @@ namespace BoostTestAdapter.Boost.Runner
             this.ListContent = null;
             this.Help = false;
 
-            this.Environment = new Dictionary<string, string>();
+            /* The environment variable "BUTA" is set whenever a test is executed. The purpose
+             * is to provide a means for boost unit tests to detect that they are being executed
+             * using the boost unit test adapter. One might use this so as for the tests to 
+             * increase the verbosity level whenever boost unit tests are executed using the
+             * boost unit test adapter.
+             */
+
+            this.Environment = new Dictionary<string, string>()
+            {
+                { "BUTA", "1" }
+            };
         }
 
         #endregion Constructors

--- a/BoostTestAdapterNunit/BoostTestExecutorTest.cs
+++ b/BoostTestAdapterNunit/BoostTestExecutorTest.cs
@@ -586,6 +586,7 @@ namespace BoostTestAdapterNunit
             );
 
             AssertDefaultTestResultProperties(this.FrameworkHandle.Results);
+
         }
 
         /// <summary>
@@ -611,6 +612,37 @@ namespace BoostTestAdapterNunit
             Assert.That(runner.ExecutionArgs.First().Context, Is.TypeOf<DebugFrameworkExecutionContext>());
 
             AssertDefaultTestResultProperties(this.FrameworkHandle.Results);
+        }
+
+        /// <summary>
+        /// "BUTA" environment variable should be set within an execution context.
+        /// 
+        /// Test aims:
+        ///     - Ensure that the text execution runner provides the environment variable "BUTA" in the execution
+        ///     context
+        /// </summary>
+        [Test]
+        public void BUTAEnvironmentVariableProvided()
+        {
+            this.RunContext.IsBeingDebugged = true;
+
+            this.Executor.RunTests(
+                GetDefaultTests(),
+                this.RunContext,
+                this.FrameworkHandle
+            );
+
+            MockBoostTestRunner runner = this.RunnerFactory.LastTestRunner as MockBoostTestRunner;
+
+            Assert.That(runner, Is.Not.Null);
+
+            var oExpectedEnvironmentVariables = new Dictionary<string, string>()
+            {
+                { "BUTA", "1" }
+            };
+
+            CollectionAssert.AreEqual(oExpectedEnvironmentVariables, runner.ExecutionArgs.First().Arguments.Environment);
+
         }
 
         /// <summary>

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -5,6 +5,7 @@
 
 using BoostTestAdapter.Boost.Runner;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.IO;
 
 namespace BoostTestAdapterNunit
@@ -69,6 +70,25 @@ namespace BoostTestAdapterNunit
         {
             BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
             Assert.That(args.ToString(), Is.Empty);
+        }
+
+        /// <summary>
+        /// "BUTA" environment variable present by default in the environment variable collection
+        /// 
+        /// Test aims:
+        ///     - Ensure that the "BUTA" environment is present by default in the enviorment variable collection.
+        /// </summary>
+        [Test]
+        public void BUTAEnviormentVariablePresent()
+        {
+            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs();
+
+            var oExpectedEnviormentVariables = new Dictionary<string, string>()
+            {
+                { "BUTA", "1" }
+            };
+
+            CollectionAssert.AreEqual(oExpectedEnviormentVariables, args.Environment);
         }
 
         /// <summary>
@@ -144,6 +164,7 @@ namespace BoostTestAdapterNunit
             Assert.That(args.ListContent, Is.EqualTo(clone.ListContent));
 
             Assert.That(args.ToString(), Is.EqualTo(clone.ToString()));
+            Assert.That(args.Environment, Is.EqualTo(clone.Environment));
         }
 
         /// <summary>


### PR DESCRIPTION
Add the functionality where Boost unit test adapter will set the environment variable "BUTA" whenever it is executing tests. This is done so as to provide a means to the developer to detect that the unit tests are being executed using boost unit test adapter. This can be useful in a scenario where for example a developer might decide to increase the verbosity level of the logs written to the standard output during the test execution.

The wiki section has already been updated [with an entry about this functionality](https://github.com/etas/vs-boost-unit-test-adapter/wiki/User-Manual#detect-from-within-a-unit-test-that-the-test-is-being-executed-using-the-boost-unit-test-adapter).  I've also updated Boost-Test-Samples.zip and added the below test

```
/**
* Boost unit test adapter sets the environment variable "BUTA" whenever it is
* executing tests. This is done so as to provide a means to the developer
* to detect that the unit tests are being executed using the boost unit test 
* adapter. This can be useful in a scenario where for example a developer
* might decide to increase the verbosity level of the logs written to the
* standard output during the test execution.
*/
BOOST_AUTO_TEST_CASE(BUTAEnvironmentVariableSet)
{
#pragma warning (disable: 4996)

	BOOST_CHECK(nullptr != std::getenv("BUTA"));
}
```