### PR TITLE
Add Support for Boost.Test version Identification

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTest162Runner.cs
@@ -41,6 +41,8 @@ namespace BoostTestAdapter.Boost.Runner
 
         public bool ListContentSupported => this.Runner.ListContentSupported;
 
+        public bool VersionSupported => this.Runner.VersionSupported;
+
         public string Source => this.Runner.Source;
 
         public int Execute(BoostTestRunnerCommandLineArgs args, BoostTestRunnerSettings settings, IProcessExecutionContext executionContext)

--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -172,6 +172,8 @@ namespace BoostTestAdapter.Boost.Runner
         internal const string ListContentArg = "--list_content";
         internal const string HelpArg = "--help";
 
+        internal const string VersionArg = "--version";
+
         private const string TestSeparator = ",";
 
         private const char ArgSeparator = ' ';
@@ -227,6 +229,7 @@ namespace BoostTestAdapter.Boost.Runner
             this.SavePattern = false;
             this.ListContent = null;
             this.Help = false;
+            this.Version = false;
 
             /* The environment variable "BUTA" is set whenever a test is executed. The purpose
              * is to provide a means for boost unit tests to detect that they are being executed
@@ -359,7 +362,7 @@ namespace BoostTestAdapter.Boost.Runner
         public string AutoStartDebug { get; set; }
 
         /// <summary>
-        /// Flag which displays Boost UTF test information in standard out.
+        /// Flag which displays Boost.Test test information in standard out.
         /// </summary>
         public bool BuildInfo { get; set; }
 
@@ -375,7 +378,7 @@ namespace BoostTestAdapter.Boost.Runner
         public bool ColorOutput { get; set; }
 
         /// <summary>
-        /// Determines the result code the Boost UTF uses on exit.
+        /// Determines the result code the Boost.Test uses on exit.
         /// </summary>
         public bool ResultCode { get; set; }
 
@@ -390,7 +393,7 @@ namespace BoostTestAdapter.Boost.Runner
         public bool UseAltStack { get; set; }
 
         /// <summary>
-        /// Instructs the Boost UTF to break on floating-point exceptions.
+        /// Instructs the Boost.Test to break on floating-point exceptions.
         /// </summary>
         public bool DetectFPExceptions { get; set; }
 
@@ -401,7 +404,7 @@ namespace BoostTestAdapter.Boost.Runner
         public bool SavePattern { get; set; }
 
         /// <summary>
-        /// The Boost UTF lists all tests which are to be executed without actually executing the tests.
+        /// The Boost.Test lists all tests which are to be executed without actually executing the tests.
         /// </summary>
         /// <remarks>Introduced in Boost 1.59 / Boost Test 3</remarks>
         public ListContentFormat? ListContent { get; set; }
@@ -410,6 +413,11 @@ namespace BoostTestAdapter.Boost.Runner
         /// Help output.
         /// </summary>
         public bool Help { get; set; }
+
+        /// <summary>
+        /// Version information output.
+        /// </summary>
+        public bool Version { get; set; }
 
         /// <summary>
         /// Path (relative to the WorkingDirectory) to the report file which will host the standard output content.
@@ -456,7 +464,16 @@ namespace BoostTestAdapter.Boost.Runner
             {
                 AddArgument(HelpArg, args);
 
-                // return immediately since Boost UTF should ignore the rest of the arguments
+                // return immediately since Boost.Test should ignore the rest of the arguments
+                return AppendRedirection(args).ToString().TrimEnd();
+            }
+
+            // --version
+            if (this.Version)
+            {
+                AddArgument(VersionArg, args);
+
+                // return immediately since Boost.Test should ignore the rest of the arguments
                 return AppendRedirection(args).ToString().TrimEnd();
             }
 
@@ -465,7 +482,7 @@ namespace BoostTestAdapter.Boost.Runner
             {
                 AddArgument(ListContentArg, ListContentFormatToString(this.ListContent.Value), args);
 
-                // return immediately since Boost UTF should ignore the rest of the arguments
+                // return immediately since Boost.Test should ignore the rest of the arguments
                 return AppendRedirection(args).ToString().TrimEnd();
             }
 
@@ -817,6 +834,8 @@ namespace BoostTestAdapter.Boost.Runner
             clone.DetectFPExceptions = this.DetectFPExceptions;
             clone.SavePattern = this.SavePattern;
             clone.ListContent = this.ListContent;
+            clone.Help = this.Help;
+            clone.Version = this.Version;
 
             return clone;
         }

--- a/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/ExternalBoostTestRunner.cs
@@ -50,7 +50,10 @@ namespace BoostTestAdapter.Boost.Runner
 
         public override string Source
         {
-            get { return this._source; }
+            get
+            {
+                return this._source;
+            }
         }
 
         public override bool ListContentSupported
@@ -60,6 +63,8 @@ namespace BoostTestAdapter.Boost.Runner
                 return (Settings.DiscoveryMethodType == DiscoveryMethodType.DiscoveryListContent);
             }
         }
+
+        public override bool VersionSupported { get; } = false;
 
         #endregion IBoostTestRunner
 

--- a/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
+++ b/BoostTestAdapter/Boost/Runner/IBoostTestRunner.cs
@@ -31,5 +31,10 @@ namespace BoostTestAdapter.Boost.Runner
         /// Determines if the test runner provides --list_content capabilities.
         /// </summary>
         bool ListContentSupported { get; }
+
+        /// <summary>
+        /// Determines if the test runner provides --version capabilities.
+        /// </summary>
+        bool VersionSupported { get; }
     }
 }

--- a/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
+++ b/BoostTestAdapter/Discoverers/VSDiscoveryVisitor.cs
@@ -31,10 +31,22 @@ namespace BoostTestAdapter.Discoverers
         /// <param name="source">The source test module which contains the discovered tests</param>
         /// <param name="sink">The ITestCaseDiscoverySink which will have tests registered with</param>
         public VSDiscoveryVisitor(string source, ITestCaseDiscoverySink sink)
+            : this(source, string.Empty, sink)
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="source">The source test module which contains the discovered tests</param>
+        /// <param name="version">The source test module Boost.Test version</param>
+        /// <param name="sink">The ITestCaseDiscoverySink which will have tests registered with</param>
+        public VSDiscoveryVisitor(string source, string version, ITestCaseDiscoverySink sink)
         {
             Code.Require(sink, "sink");
 
             this.Source = source;
+            this.Version = version;
             this.DiscoverySink = sink;
             this.OutputLog = true;
         }
@@ -43,6 +55,11 @@ namespace BoostTestAdapter.Discoverers
         /// The test module source file path
         /// </summary>
         public string Source { get; private set; }
+
+        /// <summary>
+        /// The test module version
+        /// </summary>
+        public string Version { get; private set; }
 
         /// <summary>
         /// Whether the module should output to the logger regarding relative paths
@@ -153,6 +170,12 @@ namespace BoostTestAdapter.Discoverers
                 // Test cases inherit the labels of parent test units
                 // Reference: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/tests_organization/tests_grouping.html
                 unit = unit.Parent;
+            }
+
+            // Record Boost version if available
+            if (!string.IsNullOrEmpty(this.Version))
+            {
+                test.SetPropertyValue(VSTestModel.VersionProperty, this.Version);
             }
 
             return test;

--- a/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
+++ b/BoostTestAdapter/Utility/VisualStudio/VSTestModel.cs
@@ -46,12 +46,25 @@ namespace BoostTestAdapter.Utility.VisualStudio
             }
         }
 
+        private static readonly TestProperty _version = TestProperty.Register("Boost.Test.Boost.Version", "Boost Version", typeof(string), typeof(VSTestModel));
+
+        /// <summary>
+        /// Boost.Test Boost Version property
+        /// </summary>
+        public static TestProperty VersionProperty
+        {
+            get
+            {
+                return _version;
+            }
+        }
+        
         /// <summary>
         /// Converts forward slashes in a file path to backward slashes.
         /// </summary>
         /// <param name="path_in"> The input path</param>
         /// <returns>The output path, modified with backward slashes </returns>
-       
+
         private static string ConvertSlashes(string path_in)
         {
             return path_in.Replace('/', '\\');

--- a/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
+++ b/BoostTestAdapterNunit/BoostTestAdapterNunit.csproj
@@ -124,6 +124,7 @@
     <EmbeddedResource Include="Resources\ListContentDOT\test_list_content.gv" />
     <EmbeddedResource Include="Resources\ListContentDOT\boost_data_test_case.gv" />
     <EmbeddedResource Include="Resources\Log4NetConfigFile\BoostTestAdapter.TestAdapter.dll.config" />
+    <EmbeddedResource Include="Resources\Version\sample.version.stderr.log" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\ReportsLogs\AbortedTest\sample.test.log.xml" />

--- a/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
+++ b/BoostTestAdapterNunit/BoostTestDiscovererTest.cs
@@ -116,13 +116,9 @@ namespace BoostTestAdapterNunit
             this.Source = source;
         }
 
-        public bool ListContentSupported
-        {
-            get
-            {
-                return true;
-            }
-        }
+        public bool ListContentSupported { get; } = true;
+
+        public bool VersionSupported { get; } = false;
 
         public string Source { get; private set; }
 

--- a/BoostTestAdapterNunit/BoostTestExecutorTest.cs
+++ b/BoostTestAdapterNunit/BoostTestExecutorTest.cs
@@ -368,8 +368,10 @@ namespace BoostTestAdapterNunit
 
             public bool ListContentSupported { get; private set; }
 
+            public bool VersionSupported { get; } = false;
+
             #endregion IBoostTestRunner
-            
+
             private void Copy(string embeddedResource, string path)
             {
                 using (Stream inStream = TestHelper.LoadEmbeddedResource(embeddedResource))

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -162,6 +162,8 @@ namespace BoostTestAdapterNunit
             Assert.That(args.DetectFPExceptions, Is.EqualTo(clone.DetectFPExceptions));
             Assert.That(args.SavePattern, Is.EqualTo(clone.SavePattern));
             Assert.That(args.ListContent, Is.EqualTo(clone.ListContent));
+            Assert.That(args.Help, Is.EqualTo(clone.Help));
+            Assert.That(args.Version, Is.EqualTo(clone.Version));
 
             Assert.That(args.ToString(), Is.EqualTo(clone.ToString()));
             Assert.That(args.Environment, Is.EqualTo(clone.Environment));
@@ -215,6 +217,33 @@ namespace BoostTestAdapterNunit
             
             // list content only includes the --list_content and the output redirection commands
             Assert.That(args.ToString(), Is.EqualTo(expected));
+        }
+
+        /// <summary>
+        /// Assert that: A Boost.Test command-line requiring version output is generated accordingly
+        /// </summary>
+        [Test]
+        public void VersionCommandLineArgs()
+        {
+            BoostTestRunnerCommandLineArgs args = new BoostTestRunnerCommandLineArgs()
+            {
+                Version = true
+            };
+
+            // Version without output redirection
+            {
+                const string expected = "\"--version\"";
+                Assert.That(args.ToString(), Is.EqualTo(expected));
+            }
+
+            // Version with output redirection
+            {
+                args.StandardOutFile = @"C:\Temp\version.out";
+                args.StandardErrorFile = @"C:\Temp\version.err";
+
+                const string expected = "\"--version\" > \"C:\\Temp\\version.out\" 2> \"C:\\Temp\\version.err\"";
+                Assert.That(args.ToString(), Is.EqualTo(expected));
+            }
         }
 
         #endregion Tests

--- a/BoostTestAdapterNunit/ListContentDiscovererTest.cs
+++ b/BoostTestAdapterNunit/ListContentDiscovererTest.cs
@@ -78,6 +78,7 @@ namespace BoostTestAdapterNunit
             string output = null;
 
             A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(false);
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
             {
                 BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) call.Arguments.First();
@@ -136,6 +137,7 @@ namespace BoostTestAdapterNunit
             IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
                         
             A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(false);
             A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Returns(-1073741515);
 
             FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
@@ -148,6 +150,95 @@ namespace BoostTestAdapterNunit
             
             // Ensure proper test discovery
             Assert.That(sink.Tests.Count, Is.EqualTo(0));
+        }
+
+        /// <summary>
+        /// Assert that: Given a Boost.Test module which supports --version, all discovered tests are annotated accordingly
+        /// </summary>
+        [Test]
+        public void VersionAnnotation()
+        {
+            IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
+
+            A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(true);
+            A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
+            {
+                BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs) call.Arguments.First();
+
+                // --list_content=DOT
+                if ((args.ListContent.HasValue) && (args.ListContent.Value == ListContentFormat.DOT) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.ListContentDOT.sample.3.list.content.gv", args.StandardErrorFile);
+                }
+                // --version
+                else if ((args.Version) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.Version.sample.version.stderr.log", args.StandardErrorFile);
+                }
+            }).Returns(0);
+
+            FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
+            ListContentDiscoverer discoverer = new ListContentDiscoverer(factory, DummyVSProvider.Default);
+
+            DefaultTestContext context = new DefaultTestContext();
+            DefaultTestCaseDiscoverySink sink = new DefaultTestCaseDiscoverySink();
+
+            discoverer.DiscoverTests(new[] { "test.exe", }, context, sink);
+
+            // Ensure proper test discovery
+            Assert.That(sink.Tests.Count, Is.Not.EqualTo(0));
+
+            // Ensure that version property is available
+            foreach (var test in sink.Tests)
+            {
+                var version = test.GetPropertyValue(VSTestModel.VersionProperty);
+                Assert.That(version, Is.EqualTo("1.63.0"));
+            }
+        }
+
+        /// <summary>
+        /// Assert that: Given a Boost.Test module which does not support --version, all discovered tests do not advertise the Boost version
+        /// </summary>
+        [Test]
+        public void NoVersionCapabilities()
+        {
+            IBoostTestRunner runner = A.Fake<IBoostTestRunner>();
+
+            A.CallTo(() => runner.ListContentSupported).Returns(true);
+            A.CallTo(() => runner.VersionSupported).Returns(false);
+            A.CallTo(() => runner.Execute(A<BoostTestRunnerCommandLineArgs>._, A<BoostTestRunnerSettings>._, A<IProcessExecutionContext>._)).Invokes((call) =>
+            {
+                BoostTestRunnerCommandLineArgs args = (BoostTestRunnerCommandLineArgs)call.Arguments.First();
+
+                // --list_content=DOT
+                if ((args.ListContent.HasValue) && (args.ListContent.Value == ListContentFormat.DOT) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.ListContentDOT.sample.3.list.content.gv", args.StandardErrorFile);
+                }
+                // --version
+                else if ((args.Version) && (!string.IsNullOrEmpty(args.StandardErrorFile)))
+                {
+                    TestHelper.CopyEmbeddedResourceToDirectory("BoostTestAdapterNunit.Resources.Version.missing.version.stderr.log", args.StandardErrorFile);
+                }
+            }).Returns(0);
+
+            FakeBoostTestRunnerFactory factory = new FakeBoostTestRunnerFactory(runner);
+            ListContentDiscoverer discoverer = new ListContentDiscoverer(factory, DummyVSProvider.Default);
+
+            DefaultTestContext context = new DefaultTestContext();
+            DefaultTestCaseDiscoverySink sink = new DefaultTestCaseDiscoverySink();
+
+            discoverer.DiscoverTests(new[] { "test.exe", }, context, sink);
+
+            // Ensure proper test discovery
+            Assert.That(sink.Tests.Count, Is.Not.EqualTo(0));
+
+            // Ensure that version property is not available
+            foreach (var test in sink.Tests)
+            {
+                Assert.That(test.GetPropertyValue(VSTestModel.VersionProperty), Is.Null);
+            }
         }
     }
 }

--- a/BoostTestAdapterNunit/Resources/Version/missing.version.stderr.log
+++ b/BoostTestAdapterNunit/Resources/Version/missing.version.stderr.log
@@ -1,0 +1,8 @@
+An unrecognized parameter in the argument version
+
+Usage: test.exe [Boost.Test argument]... -- [custom test module argument]...
+
+For detailed help on Boost.Test parameters use:
+  test.exe --help
+or
+  test.exe --help=<parameter name>

--- a/BoostTestAdapterNunit/Resources/Version/sample.version.stderr.log
+++ b/BoostTestAdapterNunit/Resources/Version/sample.version.stderr.log
@@ -1,0 +1,5 @@
+Boost.Test module in executable 'test.exe'
+Compiled from Boost version 1.63.0 with static linking to Boost.Test
+- Compiler: Microsoft Visual C++ version 14.0
+- Platform: Win32
+- STL     : Dinkumware standard library version 650


### PR DESCRIPTION
The Boost.Test version is now queried via the `--version` command-line argument introduced in Boost 1.63.

This solution ensures backwards compatibility and avoids executing `--version` if the debug symbol cannot be located. If located, the test module is executed an additional time prior to discovery to query the version. This information is then passed onto the execution phase without the need of additional module executions.

Closes #173