### PR TITLE
Set 'CatchSystemErrors' Based on Execution Mode

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerCommandLineArgs.cs
@@ -218,7 +218,7 @@ namespace BoostTestAdapter.Boost.Runner
             this.ShowProgress = false;
             this.BuildInfo = false;
             this.AutoStartDebug = "no";
-            this.CatchSystemErrors = true;
+            this.CatchSystemErrors = null;
             this.ColorOutput = false;
             this.ResultCode = true;
             this.Random = 0;
@@ -366,7 +366,13 @@ namespace BoostTestAdapter.Boost.Runner
         /// <summary>
         /// Determines whether system errors should be caught.
         /// </summary>
-        public bool CatchSystemErrors { get; set; }
+        /// <remarks>
+        /// Since the default value of '--catch_system_errors' is dependent on Boost.Test's 
+        /// '#define BOOST_TEST_DEFAULTS_TO_CORE_DUMP', this value has been set to a optional type
+        /// 
+        /// Reference: http://www.boost.org/doc/libs/1_60_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/catch_system.html
+        /// </remarks>
+        public bool? CatchSystemErrors { get; set; }
 
         /// <summary>
         /// States whether standard output text is colour coded.
@@ -493,10 +499,10 @@ namespace BoostTestAdapter.Boost.Runner
                 AddArgument(AutoStartDebugArg, this.AutoStartDebug, args);
             }
 
-            // --catch_system_errors=no
-            if (!this.CatchSystemErrors)
+            // --catch_system_errors=yes
+            if (this.CatchSystemErrors.HasValue)
             {
-                AddArgument(CatchSystemErrorsArg, No, args);
+                AddArgument(CatchSystemErrorsArg, (this.CatchSystemErrors.Value ? Yes : No), args);
             }
 
             // --color_output=yes

--- a/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
+++ b/BoostTestAdapter/Settings/BoostTestAdapterSettings.cs
@@ -37,7 +37,7 @@ namespace BoostTestAdapter.Settings
 
             this.LogLevel = LogLevel.TestSuite;
             
-            this.CatchSystemErrors = true;
+            this.CatchSystemErrors = null;
 
             this.DetectFloatingPointExceptions = false;
 
@@ -102,8 +102,8 @@ namespace BoostTestAdapter.Settings
         /// <summary>
         /// Set to 'true'|'1' to enable Boost Test's catch_system_errors.
         /// </summary>
-        [DefaultValue(true)]
-        public bool CatchSystemErrors
+        [DefaultValue(null)]
+        public bool? CatchSystemErrors
         {
             get
             {

--- a/BoostTestAdapterNunit/BoostTestExecutorTest.cs
+++ b/BoostTestAdapterNunit/BoostTestExecutorTest.cs
@@ -577,6 +577,11 @@ namespace BoostTestAdapterNunit
             );
 
             AssertDefaultTestResultProperties(this.FrameworkHandle.Results);
+
+            MockBoostTestRunner runner = this.RunnerFactory.LastTestRunner as MockBoostTestRunner;
+
+            Assert.That(runner, Is.Not.Null);
+            Assert.That(runner.ExecutionArgs.All(args => (!args.Arguments.CatchSystemErrors.HasValue || args.Arguments.CatchSystemErrors.Value)), Is.True);
         }
 
         /// <summary>
@@ -614,6 +619,10 @@ namespace BoostTestAdapterNunit
 
             AssertDefaultTestResultProperties(this.FrameworkHandle.Results);
 
+            MockBoostTestRunner runner = this.RunnerFactory.LastTestRunner as MockBoostTestRunner;
+
+            Assert.That(runner, Is.Not.Null);
+            Assert.That(runner.ExecutionArgs.All(args => (!args.Arguments.CatchSystemErrors.HasValue || args.Arguments.CatchSystemErrors.Value)), Is.True);
         }
 
         /// <summary>
@@ -637,6 +646,7 @@ namespace BoostTestAdapterNunit
 
             Assert.That(runner, Is.Not.Null);
             Assert.That(runner.ExecutionArgs.First().Context, Is.TypeOf<DebugFrameworkExecutionContext>());
+            Assert.That(runner.ExecutionArgs.All(args => (args.Arguments.CatchSystemErrors.HasValue && !args.Arguments.CatchSystemErrors.Value)), Is.True);
 
             AssertDefaultTestResultProperties(this.FrameworkHandle.Results);
         }

--- a/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestRunnerCommandLineArgsTest.cs
@@ -6,7 +6,6 @@
 using BoostTestAdapter.Boost.Runner;
 using NUnit.Framework;
 using System.Collections.Generic;
-using System.IO;
 
 namespace BoostTestAdapterNunit
 {
@@ -46,7 +45,7 @@ namespace BoostTestAdapterNunit
 
             args.DetectMemoryLeaks = 0;
 
-            args.CatchSystemErrors = false;
+            args.CatchSystemErrors = true;
             args.DetectFPExceptions = true;
 
             args.StandardOutFile = GenerateFullyQualifiedPath("stdout.log");
@@ -102,7 +101,7 @@ namespace BoostTestAdapterNunit
         {
             BoostTestRunnerCommandLineArgs args = GenerateCommandLineArgs();
             // serge: boost 1.60 requires uppercase input
-            Assert.That(args.ToString(), Is.EqualTo("\"--run_test=test,suite/*\" \"--catch_system_errors=no\" \"--log_format=XML\" \"--log_level=test_suite\" \"--log_sink="
+            Assert.That(args.ToString(), Is.EqualTo("\"--run_test=test,suite/*\" \"--catch_system_errors=yes\" \"--log_format=XML\" \"--log_level=test_suite\" \"--log_sink="
                 + GenerateFullyQualifiedPath("log.xml") + "\" \"--report_format=XML\" \"--report_level=detailed\" \"--report_sink="
                 + GenerateFullyQualifiedPath("report.xml") + "\" \"--detect_memory_leak=0\" \"--detect_fp_exceptions=yes\" > \"" 
                 + GenerateFullyQualifiedPath("stdout.log") + "\" 2> \""

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -60,7 +60,7 @@ namespace BoostTestAdapterNunit
             Assert.That(settings.LogLevel, Is.EqualTo(LogLevel.TestSuite));
             Assert.That(settings.ExternalTestRunner, Is.Null);
             Assert.That(settings.DetectFloatingPointExceptions, Is.False);
-            Assert.That(settings.CatchSystemErrors, Is.True);
+            Assert.That(settings.CatchSystemErrors, Is.Null);
             Assert.That(settings.TestBatchStrategy, Is.EqualTo(Strategy.TestCase));
             Assert.That(settings.ForceListContent, Is.False);
             Assert.That(settings.WorkingDirectory, Is.Null);
@@ -169,7 +169,10 @@ namespace BoostTestAdapterNunit
         ///     - Assert that: the Boost 1.62 workaround option can be parsed
         /// </summary>
         [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><UseBoost162Workaround>true</UseBoost162Workaround></BoostTest></RunSettings>", Result = true)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><UseBoost162Workaround>1</UseBoost162Workaround></BoostTest></RunSettings>", Result = true)]
         [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><UseBoost162Workaround>false</UseBoost162Workaround></BoostTest></RunSettings>", Result = false)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><UseBoost162Workaround>0</UseBoost162Workaround></BoostTest></RunSettings>", Result = false)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><UseBoost162Workaround /></BoostTest></RunSettings>", Result = false)]
         [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest /></RunSettings>", Result = false)]
         public bool ParseWorkaroundOption(string settingsXml)
         {
@@ -192,6 +195,23 @@ namespace BoostTestAdapterNunit
         {
             BoostTestAdapterSettings settings = ParseXml(settingsXml);
             return settings.PostTestDelay;
+        }
+
+        /// <summary>
+        /// The 'CatchSystemErrors' option can be properly parsed
+        /// 
+        /// Test aims:
+        ///     - Assert that: the 'CatchSystemErrors' option can be properly parsed
+        /// </summary>
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>true</CatchSystemErrors></BoostTest></RunSettings>", Result = true)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>1</CatchSystemErrors></BoostTest></RunSettings>", Result = true)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>false</CatchSystemErrors></BoostTest></RunSettings>", Result = false)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest><CatchSystemErrors>0</CatchSystemErrors></BoostTest></RunSettings>", Result = false)]
+        [TestCase("<?xml version=\"1.0\" encoding=\"utf-8\"?><RunSettings><BoostTest /></RunSettings>", Result = null)]
+        public bool? ParseCatchSystemErrorsOption(string settingsXml)
+        {
+            BoostTestAdapterSettings settings = ParseXml(settingsXml);
+            return settings.CatchSystemErrors;
         }
 
         #endregion Tests


### PR DESCRIPTION
If the tests are executed in 'debug' (e.g. via right-click 'Debug Test') the `CatchSystemErrors` command-line argument is specified to `false` to allow the debugger to intervene. In 'regular' execution, this switch is inverted and expects the Boost.Test framework to catch such exceptions and identify them as test failures. The value of this argument can be overridden via configuration.

In addition, the default value of 'CatchSystemErrors' has been changed to reflect the change from Boost 1.59 to Boost 1.60.

Closes #194