### PR TITLE
Properly handle ROTException

### DIFF
--- a/BoostTestAdapter/BoostTestExecutor.cs
+++ b/BoostTestAdapter/BoostTestExecutor.cs
@@ -470,6 +470,10 @@ namespace BoostTestAdapter
 
                 args.SetWorkingEnvironment(source, settings, vs);
             }
+            catch (ROTException ex)
+            {
+                Logger.Exception(ex, "Could not retrieve WorkingDirectory from Visual Studio Configuration");
+            }
             catch (COMException ex)
             {
                 Logger.Exception(ex, "Could not retrieve WorkingDirectory from Visual Studio Configuration-{0}", ex.Message);

--- a/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
+++ b/BoostTestAdapter/Discoverers/ListContentDiscoverer.cs
@@ -99,6 +99,10 @@ namespace BoostTestAdapter.Discoverers
 
                     args.SetWorkingEnvironment(source, settings, vs);
                 }
+                catch (ROTException ex)
+                {
+                    Logger.Exception(ex, "Could not retrieve WorkingDirectory from Visual Studio Configuration");
+                }
                 catch (COMException ex)
                 {
                     Logger.Exception(ex, "Could not retrieve WorkingDirectory from Visual Studio Configuration");

--- a/BoostTestAdapter/Utility/NativeMethods.cs
+++ b/BoostTestAdapter/Utility/NativeMethods.cs
@@ -57,7 +57,8 @@ namespace BoostTestAdapter.Utility
 
                     if (createBindCtxReturnCode != S_OK)
                     {
-                        throw new ROTException("CreateBindCtx returned with code:" + createBindCtxReturnCode);
+                        // Avoid throwing at this point. Skip entry and continue the iteration.
+                        continue;
                     }
 
                     string runningObjectName;
@@ -69,7 +70,7 @@ namespace BoostTestAdapter.Utility
 
                     if (getObjectReturnValue != S_OK)
                     {
-                        throw new ROTException("IRunningObjectTable::GetObject returned with code:" + getObjectReturnValue);
+                        runningObjectVal = null;
                     }
 
                     yield return new KeyValuePair<string, object>(runningObjectName, runningObjectVal);


### PR DESCRIPTION
In cases where the entries in the COM Running Object Table are inaccessible or busy, avoid throwing fatal exceptions which halt the iteration. If the table itself is inaccessible, properly handle the exception.

Closes #200