### PR TITLE
Change 'ForceListContent' Filename Pattern

### DIFF
--- a/BoostTestAdapter/Discoverers/BoostTestDiscovererFactory.cs
+++ b/BoostTestAdapter/Discoverers/BoostTestDiscovererFactory.cs
@@ -3,13 +3,15 @@
 // (See accompanying file LICENSE_1_0.txt or copy at
 // http://www.boost.org/LICENSE_1_0.txt)
 
-using System.Collections.Generic;
+using System;
 using System.IO;
 using System.Linq;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
 using BoostTestAdapter.Discoverers;
 using BoostTestAdapter.Boost.Runner;
 using BoostTestAdapter.Settings;
-using System;
 
 namespace BoostTestAdapter
 {
@@ -17,8 +19,11 @@ namespace BoostTestAdapter
     {
         #region Constants
 
-        private static string ForceListContentExtension { get { return ".test.boostd.exe"; } }
-
+        /// <summary>
+        /// Default 'ForceListContent' filename pattern. Such filenames are assumed to be valid Boost.Test modules by default.
+        /// </summary>
+        private static readonly Regex _forceListContentExtensionPattern = new Regex(@"test\.boost(?:d)?\.exe$", RegexOptions.IgnoreCase);
+        
         #endregion 
 
         #region Constructors
@@ -87,8 +92,10 @@ namespace BoostTestAdapter
                 }
 
                 // Skip modules which are not .exe
-                if (extension != BoostTestDiscoverer.ExeExtension)
+                if (string.Compare(extension, BoostTestDiscoverer.ExeExtension, true) != 0)
+                {
                     continue;
+                }
 
                 // Ensure that the source is a Boost.Test module if it supports '--list_content'
                 if (((settings.ForceListContent) || IsListContentSupported(source, settings)))
@@ -133,9 +140,8 @@ namespace BoostTestAdapter
 
             IBoostTestRunner runner = _factory.GetRunner(source, options);
 
-            // Convention over configuration. Assume test runners utilising such an extension
-            return (runner != null) && (runner.Source.EndsWith(ForceListContentExtension, StringComparison.OrdinalIgnoreCase) || runner.ListContentSupported);
+            // Convention over configuration. Assume test runners utilising such an extension pattern
+            return (runner != null) && (_forceListContentExtensionPattern.IsMatch(source) || runner.ListContentSupported);
         }
-
     }
 }

--- a/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
+++ b/BoostTestAdapterNunit/DefaultTestDiscovererFactoryTest.cs
@@ -71,6 +71,23 @@ namespace BoostTestAdapterNunit
         // .test.boostd.exe
         [TestCase("test.test.boostd.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
         [TestCase("test.test.boostd.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
+        // .test.boostd.exe (case-insensitive)
+        [TestCase("test.TEST.BOOSTD.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        // .test.boost.exe
+        [TestCase("test.test.boost.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.test.boost.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
+        // .test.boostd.exe (case-insensitive)
+        [TestCase("test.TEST.BOOST.EXE", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        // .AcceptanceTest.boostd.exe
+        [TestCase("test.AcceptanceTest.boostd.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.AcceptanceTest.boostd.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
+        // .Acceptancetest.boostd.exe (case-insensitive)
+        [TestCase("test.Acceptancetest.boostd.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        // .AcceptanceTest.boost.exe
+        [TestCase("test.AcceptanceTest.boost.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
+        [TestCase("test.AcceptanceTest.boost.exe", ListContentUse.ForceUse, null, Result = typeof(ListContentDiscoverer))]
+        // .Acceptancetest.boost.exe (case-insensitive)
+        [TestCase("test.Acceptancetest.boost.exe", ListContentUse.Use, null, Result = typeof(ListContentDiscoverer))]
         // Dll types
         [TestCase("test.dll", ListContentUse.Use, null, Result = null)]
         [TestCase("test.dll", ListContentUse.Use, ".dll", Result = typeof(ExternalDiscoverer))]
@@ -85,6 +102,8 @@ namespace BoostTestAdapterNunit
         [TestCase("test.txt", ListContentUse.ForceUse, null, Result = null)]
         [TestCase("test.txt", ListContentUse.ForceUse, ".dll", Result = null)]
         [TestCase("test.txt", ListContentUse.ForceUse, ".exe", Result = null)]
+        [TestCase("test.test.Acceptance.boostd.exe", ListContentUse.Use, null, Result = null)]
+        [TestCase("test.test.Acceptance.boost.exe", ListContentUse.Use, null, Result = null)]
         public Type TestDiscovererProvisioning(string source, ListContentUse listContent, string externalExtension)
         {
             ExternalBoostTestRunnerSettings externalSettings = null;


### PR DESCRIPTION
The default 'ForceListContent' extension has been amended to accept file patterns which match:

- `*test.boostd.exe`
- `*test.boost.exe`

Addresses #205.