### PR TITLE
Avoid Quoting Quoted Paths

### DIFF
--- a/BoostTestAdapter/Utility/ExecutionContext/DefaultProcessExecutionContext.cs
+++ b/BoostTestAdapter/Utility/ExecutionContext/DefaultProcessExecutionContext.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 
 using JobManagement;
 
@@ -12,7 +13,7 @@ namespace BoostTestAdapter.Utility.ExecutionContext
 {
     /// <summary>
     /// An IProcessExecutionContext which produces regular sub-processes.
-    /// Guarantees that sub-processes are destoryed when this processes is killed.
+    /// Guarantees that sub-processes are destroyed when this processes is killed.
     /// </summary>
     public class DefaultProcessExecutionContext : IProcessExecutionContext
     {
@@ -101,10 +102,10 @@ namespace BoostTestAdapter.Utility.ExecutionContext
                 WindowStyle = ProcessWindowStyle.Hidden,
 
                 WorkingDirectory = args.WorkingDirectory,
-                
+
                 // Start the process through cmd.exe to allow redirection operators to work as expected
                 FileName = "cmd.exe",
-                Arguments = "/S /C \"\"" + args.FilePath + "\" " + args.Arguments + '"',
+                Arguments = string.Format(CultureInfo.InvariantCulture, "/S /C \"{0}\"", new CommandLine(args.FilePath, args.Arguments).ToString()),
 
                 // Redirection should be specified as part of 'args.Arguments' and sent to a file
                 RedirectStandardError = false,

--- a/BoostTestAdapterNunit/BoostTestSettingsTest.cs
+++ b/BoostTestAdapterNunit/BoostTestSettingsTest.cs
@@ -106,7 +106,7 @@ namespace BoostTestAdapterNunit
 
             Assert.That(settings.ExternalTestRunner, Is.Not.Null);
             Assert.That(settings.ExternalTestRunner.ExtensionType.ToString(), Is.EqualTo(".dll"));
-            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test {source} "));
+            Assert.That(settings.ExternalTestRunner.ExecutionCommandLine.ToString(), Is.EqualTo("C:\\ExternalTestRunner.exe --test {source}"));
         }
 
         /// <summary>


### PR DESCRIPTION
When attempting to use an external test runner with a .runsettings as attached [external.test.runner.runsettings.txt](https://github.com/etas/vs-boost-unit-test-adapter/files/1437884/external.test.runner.runsettings.txt), test listing and execution fails.

Issue boils down to unnecessary quotation marks when generating the command-line arguments for `cmd.exe`.

This change avoids adding unnecessary quotation marks to the test module should it already be quoted.

