### PR TITLE
Assume Exit Code of 0

### DIFF
--- a/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
+++ b/BoostTestAdapter/Boost/Runner/BoostTestRunnerBase.cs
@@ -116,11 +116,24 @@ namespace BoostTestAdapter.Boost.Runner
                 throw new TimeoutException(timeout);
             }
 
-            return process.ExitCode;
+            try
+            {
+                return process.ExitCode;
+            }
+            catch (InvalidOperationException)
+            {
+                // This is a common scenario when attempting to request the exit code
+                // of a process which is executed through the debugger. In such cases
+                // assume a successful exit scenario. Should this not be the case, the
+                // adapter will 'naturally' fail in other instances e.g. when attempting
+                // to read test reports.
+
+                return 0;
+            }
         }
 
         /// <summary>
-        ///     Kills a process identified by its pid and all its children processes
+        /// Kills a process identified by its pid and all its children processes
         /// </summary>
         /// <param name="process">process object</param>
         /// <returns></returns>

--- a/BoostTestAdapter/Utility/Logger.cs
+++ b/BoostTestAdapter/Utility/Logger.cs
@@ -161,6 +161,8 @@ namespace BoostTestAdapter.Utility
             Code.Require(ex, "ex");
 
             Error(format, args);
+
+            Debug("Exception Type: {0}", ex.GetType());
             Debug(ex.StackTrace);
         }
 


### PR DESCRIPTION
In cases when a test module process is spawned by the Visual Studio debug framework, attempting to query the `Process.ExitCode` throws an exception.

This change assumes an exit code of 0 in such cases. This assumption is validated by the fact that should this assumption not hold, the adapter will fail at other points of its execution, leading to expected user behaviour.